### PR TITLE
feat(session): add configurable session encoding with migration support

### DIFF
--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -143,7 +143,7 @@ describe('AuthKitCore', () => {
   });
 
   describe('encryptSession()', () => {
-    it('encrypts session data', async () => {
+    it('encrypts session data (sealed, default)', async () => {
       const session = {
         accessToken: 'test-token',
         refreshToken: 'test-refresh',
@@ -178,10 +178,53 @@ describe('AuthKitCore', () => {
         }),
       ).rejects.toThrow(SessionEncryptionError);
     });
+
+    it('write:unsealed produces base64url JSON', async () => {
+      const unsealed = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'sealed', write: 'unsealed' },
+        } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+      const session = {
+        accessToken: 'tok',
+        refreshToken: 'ref',
+        user: mockUser,
+        impersonator: undefined,
+      };
+
+      const result = await unsealed.encryptSession(session);
+
+      // Must be valid base64url (no +, /, =) and decodable as JSON
+      expect(result).not.toContain('+');
+      expect(result).not.toContain('/');
+      expect(result).not.toContain('=');
+      const decoded = JSON.parse(Buffer.from(result, 'base64url').toString());
+      expect(decoded.accessToken).toBe('tok');
+    });
+
+    it('write:sealed without cookiePassword throws SessionEncryptionError', async () => {
+      const noPwCore = new AuthKitCore(
+        { ...mockConfig, cookiePassword: undefined } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+
+      await expect(
+        noPwCore.encryptSession({
+          accessToken: 'tok',
+          refreshToken: 'ref',
+          user: mockUser,
+          impersonator: undefined,
+        }),
+      ).rejects.toThrow(SessionEncryptionError);
+    });
   });
 
   describe('decryptSession()', () => {
-    it('decrypts session data', async () => {
+    it('decrypts sealed session data (default)', async () => {
       const result = await core.decryptSession('encrypted-data');
 
       expect(result.accessToken).toBe('test-access-token');
@@ -202,6 +245,124 @@ describe('AuthKitCore', () => {
       );
 
       await expect(failingCore.decryptSession('bad-data')).rejects.toThrow(
+        SessionEncryptionError,
+      );
+    });
+
+    it('read:unsealed decodes base64url JSON session', async () => {
+      const session = {
+        accessToken: 'tok',
+        refreshToken: 'ref',
+        user: mockUser,
+        impersonator: undefined,
+      };
+      const encoded = Buffer.from(JSON.stringify(session)).toString(
+        'base64url',
+      );
+
+      const unsealedCore = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'unsealed', write: 'unsealed' },
+        } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+
+      const result = await unsealedCore.decryptSession(encoded);
+      expect(result.accessToken).toBe('tok');
+      expect(result.refreshToken).toBe('ref');
+    });
+
+    it('read:unsealed throws on invalid base64url', async () => {
+      const unsealedCore = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'unsealed', write: 'unsealed' },
+        } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+
+      await expect(
+        unsealedCore.decryptSession('not-valid-json!!!'),
+      ).rejects.toThrow(SessionEncryptionError);
+    });
+
+    it('read:both falls through to unsealed when sealed fails', async () => {
+      const session = {
+        accessToken: 'tok',
+        refreshToken: 'ref',
+        user: mockUser,
+        impersonator: undefined,
+      };
+      const encoded = Buffer.from(JSON.stringify(session)).toString(
+        'base64url',
+      );
+
+      const failingEncryption = {
+        sealData: async () => 'sealed',
+        unsealData: async () => {
+          throw new Error('not sealed');
+        },
+      };
+      const bothCore = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'both', write: 'unsealed' },
+        } as any,
+        mockClient as any,
+        failingEncryption as any,
+      );
+
+      const result = await bothCore.decryptSession(encoded);
+      expect(result.accessToken).toBe('tok');
+    });
+
+    it('read:both uses sealed when sealed succeeds', async () => {
+      const bothCore = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'both', write: 'sealed' },
+        } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+
+      // mockEncryption.unsealData returns test-access-token
+      const result = await bothCore.decryptSession('some-sealed-data');
+      expect(result.accessToken).toBe('test-access-token');
+    });
+
+    it('read:both throws when both formats fail', async () => {
+      const failingEncryption = {
+        sealData: async () => 'sealed',
+        unsealData: async () => {
+          throw new Error('not sealed');
+        },
+      };
+      const bothCore = new AuthKitCore(
+        {
+          ...mockConfig,
+          sessionEncoding: { read: 'both', write: 'unsealed' },
+        } as any,
+        mockClient as any,
+        failingEncryption as any,
+      );
+
+      await expect(
+        bothCore.decryptSession('not-valid-b64-json!!!'),
+      ).rejects.toThrow(SessionEncryptionError);
+    });
+
+    it('read:sealed without cookiePassword throws SessionEncryptionError', async () => {
+      const noPwCore = new AuthKitCore(
+        { ...mockConfig, cookiePassword: undefined } as any,
+        mockClient as any,
+        mockEncryption as any,
+      );
+
+      await expect(noPwCore.decryptSession('some-data')).rejects.toThrow(
         SessionEncryptionError,
       );
     });

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -10,6 +10,16 @@ import type {
   SessionEncryption,
 } from './session/types.js';
 
+function encodeUnsealed(session: Session): string {
+  return Buffer.from(JSON.stringify(session)).toString('base64url');
+}
+
+function decodeUnsealed(encoded: string): Session {
+  return JSON.parse(
+    Buffer.from(encoded, 'base64url').toString('utf-8'),
+  ) as Session;
+}
+
 /**
  * AuthKitCore provides pure business logic for authentication operations.
  *
@@ -111,37 +121,89 @@ export class AuthKitCore {
 
   /**
    * Encrypt a session object into a string suitable for cookie storage.
+   * Respects sessionEncoding.write config: 'sealed' (default) or 'unsealed'.
    *
    * @param session - The session to encrypt
-   * @returns Encrypted session string
+   * @returns Sealed or base64url-encoded session string
    * @throws SessionEncryptionError if encryption fails
    */
   async encryptSession(session: Session): Promise<string> {
+    const { write } = this.config.sessionEncoding ?? { write: 'sealed' };
+
+    if (write === 'unsealed') {
+      return encodeUnsealed(session);
+    }
+
+    // write === 'sealed'
+    if (!this.config.cookiePassword) {
+      throw new SessionEncryptionError(
+        'cookiePassword is required for sealed sessions',
+      );
+    }
     try {
-      const encryptedSession = await this.encryption.sealData(session, {
+      return await this.encryption.sealData(session, {
         password: this.config.cookiePassword,
         ttl: 0,
       });
-      return encryptedSession;
     } catch (error) {
       throw new SessionEncryptionError('Failed to encrypt session', error);
     }
   }
 
   /**
-   * Decrypt an encrypted session string back into a session object.
+   * Decrypt a session string back into a session object.
+   * Respects sessionEncoding.read config:
+   * - 'sealed' (default): iron-unseal only
+   * - 'unsealed': base64url decode only
+   * - 'both': try sealed first, fall back to unsealed
    *
-   * @param encryptedSession - The encrypted session string
+   * @param encryptedSession - The sealed or base64url-encoded session string
    * @returns Decrypted session object
    * @throws SessionEncryptionError if decryption fails
    */
   async decryptSession(encryptedSession: string): Promise<Session> {
-    try {
-      const session = await this.encryption.unsealData<Session>(
-        encryptedSession,
-        { password: this.config.cookiePassword },
+    const { read } = this.config.sessionEncoding ?? { read: 'sealed' };
+
+    if (read === 'unsealed') {
+      try {
+        return decodeUnsealed(encryptedSession);
+      } catch (error) {
+        throw new SessionEncryptionError(
+          'Failed to decode unsealed session',
+          error,
+        );
+      }
+    }
+
+    if (read === 'both') {
+      try {
+        return await this.unsealSession(encryptedSession);
+      } catch {
+        try {
+          return decodeUnsealed(encryptedSession);
+        } catch (error) {
+          throw new SessionEncryptionError(
+            'Failed to decode session in both sealed and unsealed modes',
+            error,
+          );
+        }
+      }
+    }
+
+    // read === 'sealed' (default)
+    return this.unsealSession(encryptedSession);
+  }
+
+  private async unsealSession(encryptedSession: string): Promise<Session> {
+    if (!this.config.cookiePassword) {
+      throw new SessionEncryptionError(
+        'cookiePassword is required for sealed sessions',
       );
-      return session;
+    }
+    try {
+      return await this.encryption.unsealData<Session>(encryptedSession, {
+        password: this.config.cookiePassword,
+      });
     } catch (error) {
       throw new SessionEncryptionError('Failed to decrypt session', error);
     }

--- a/src/core/config/ConfigurationProvider.spec.ts
+++ b/src/core/config/ConfigurationProvider.spec.ts
@@ -118,6 +118,75 @@ describe('ConfigurationProvider', () => {
       const config = provider.getConfig();
       expect(config.cookieName).toBe('test-cookie');
     });
+
+    it('includes cookiePassword from env var', () => {
+      const password = 'a'.repeat(32);
+      const source = vi.fn((key: string) => {
+        if (key === 'WORKOS_COOKIE_PASSWORD') return password;
+        if (key === 'WORKOS_CLIENT_ID') return 'c';
+        if (key === 'WORKOS_API_KEY') return 'k';
+        if (key === 'WORKOS_REDIRECT_URI') return 'http://localhost/cb';
+        return undefined;
+      });
+      provider.configure(source);
+
+      const config = provider.getConfig();
+      expect(config.cookiePassword).toBe(password);
+    });
+  });
+
+  describe('sessionEncoding', () => {
+    it('defaults to sealed/sealed', () => {
+      const encoding = provider.getValue('sessionEncoding');
+      expect(encoding).toEqual({ read: 'sealed', write: 'sealed' });
+    });
+
+    it('can be set programmatically', () => {
+      provider.configure({
+        sessionEncoding: { read: 'both', write: 'unsealed' },
+      });
+      expect(provider.getValue('sessionEncoding')).toEqual({
+        read: 'both',
+        write: 'unsealed',
+      });
+    });
+
+    it('reads from WORKOS_SESSION_ENCODING_READ env var', () => {
+      const source = vi.fn((key: string) => {
+        if (key === 'WORKOS_SESSION_ENCODING_READ') return 'both';
+        return undefined;
+      });
+      provider.configure(source);
+
+      const encoding = provider.getValue('sessionEncoding')!;
+      expect(encoding.read).toBe('both');
+      expect(encoding.write).toBe('sealed'); // default
+    });
+
+    it('reads from WORKOS_SESSION_ENCODING_WRITE env var', () => {
+      const source = vi.fn((key: string) => {
+        if (key === 'WORKOS_SESSION_ENCODING_WRITE') return 'unsealed';
+        return undefined;
+      });
+      provider.configure(source);
+
+      const encoding = provider.getValue('sessionEncoding')!;
+      expect(encoding.read).toBe('sealed'); // default
+      expect(encoding.write).toBe('unsealed');
+    });
+
+    it('env vars override programmatic config', () => {
+      provider.configure({
+        sessionEncoding: { read: 'unsealed', write: 'unsealed' },
+      });
+      const source = vi.fn((key: string) => {
+        if (key === 'WORKOS_SESSION_ENCODING_READ') return 'both';
+        return undefined;
+      });
+      provider.configure(source);
+
+      expect(provider.getValue('sessionEncoding')!.read).toBe('both');
+    });
   });
 
   describe('validate()', () => {
@@ -197,6 +266,32 @@ describe('ConfigurationProvider', () => {
       provider.configure(source);
 
       expect(() => provider.validate()).not.toThrow();
+    });
+
+    it('does not require cookiePassword when encoding is fully unsealed', () => {
+      provider.configure({
+        clientId: 'test-client',
+        apiKey: 'test-api-key',
+        redirectUri: 'http://localhost:3000/callback',
+        sessionEncoding: { read: 'unsealed', write: 'unsealed' },
+        // no cookiePassword
+      });
+
+      expect(() => provider.validate()).not.toThrow();
+    });
+
+    it('still requires cookiePassword when read:both (sealed fallback needed)', () => {
+      provider.configure({
+        clientId: 'test-client',
+        apiKey: 'test-api-key',
+        redirectUri: 'http://localhost:3000/callback',
+        sessionEncoding: { read: 'both', write: 'unsealed' },
+        // no cookiePassword
+      });
+
+      expect(() => provider.validate()).toThrow(
+        /WORKOS_COOKIE_PASSWORD is required/,
+      );
     });
   });
 });

--- a/src/core/config/ConfigurationProvider.ts
+++ b/src/core/config/ConfigurationProvider.ts
@@ -1,4 +1,4 @@
-import type { AuthKitConfig, ValueSource } from './types.js';
+import type { AuthKitConfig, SessionEncoding, ValueSource } from './types.js';
 
 /**
  * Default environment variable source that uses process.env
@@ -29,6 +29,10 @@ export class ConfigurationProvider {
     // act as the actual time-limited aspects of the session.
     cookieMaxAge: 60 * 60 * 24 * 400,
     apiHostname: 'api.workos.com',
+    sessionEncoding: { read: 'sealed', write: 'sealed' },
+    // cookiePassword is listed here so it always appears in allKeys in getConfig().
+    // The actual value comes from env vars or programmatic configuration.
+    cookiePassword: undefined,
   };
 
   private valueSource: ValueSource = defaultSource;
@@ -37,7 +41,7 @@ export class ConfigurationProvider {
     'clientId',
     'apiKey',
     'redirectUri',
-    'cookiePassword',
+    // cookiePassword is validated conditionally in validate() based on sessionEncoding
   ];
 
   /**
@@ -71,7 +75,32 @@ export class ConfigurationProvider {
     }
   }
 
+  /**
+   * Resolve sessionEncoding by merging programmatic config with env vars.
+   * Env vars WORKOS_SESSION_ENCODING_READ and WORKOS_SESSION_ENCODING_WRITE override config.
+   */
+  private resolveSessionEncoding(): SessionEncoding {
+    const configValue = this.config.sessionEncoding ?? {
+      read: 'sealed' as const,
+      write: 'sealed' as const,
+    };
+    const readEnv = this.getEnvironmentValue('WORKOS_SESSION_ENCODING_READ');
+    const writeEnv = this.getEnvironmentValue('WORKOS_SESSION_ENCODING_WRITE');
+    if (!readEnv && !writeEnv) {
+      return configValue;
+    }
+    return {
+      read: (readEnv ?? configValue.read) as SessionEncoding['read'],
+      write: (writeEnv ?? configValue.write) as SessionEncoding['write'],
+    };
+  }
+
   getValue<K extends keyof AuthKitConfig>(key: K): AuthKitConfig[K] {
+    // sessionEncoding is resolved via dedicated env vars, not the standard mapping
+    if (key === 'sessionEncoding') {
+      return this.resolveSessionEncoding() as AuthKitConfig[K];
+    }
+
     const envKey = this.getEnvironmentVariableName(key);
     const envValue = this.getEnvironmentValue(envKey);
 
@@ -155,12 +184,25 @@ export class ConfigurationProvider {
 
       if (!value) {
         errors.push(`${envKey} is required`);
-      } else if (key === 'cookiePassword') {
-        // Special validation for cookiePassword length
+      }
+    }
+
+    // Validate cookiePassword conditionally — not needed for fully unsealed encoding
+    const encoding = this.resolveSessionEncoding();
+    const needsPassword = !(
+      encoding.read === 'unsealed' && encoding.write === 'unsealed'
+    );
+    if (needsPassword) {
+      const envValue = this.getEnvironmentValue('WORKOS_COOKIE_PASSWORD');
+      const configValue = this.config.cookiePassword;
+      const value = envValue ?? configValue;
+      if (!value) {
+        errors.push('WORKOS_COOKIE_PASSWORD is required');
+      } else {
         const password = String(value);
         if (password.length < 32) {
           errors.push(
-            `${envKey} must be at least 32 characters (currently ${password.length})`,
+            `WORKOS_COOKIE_PASSWORD must be at least 32 characters (currently ${password.length})`,
           );
         }
       }

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -1,4 +1,18 @@
 /**
+ * Session encoding configuration for gradual migration between sealed and unsealed formats.
+ *
+ * - `read: 'sealed'` — only accept iron-encrypted cookies (default)
+ * - `read: 'unsealed'` — only accept base64url JSON cookies
+ * - `read: 'both'` — try sealed first, fall back to unsealed (migration phase)
+ * - `write: 'sealed'` — write iron-encrypted cookies (default)
+ * - `write: 'unsealed'` — write base64url JSON cookies
+ */
+export interface SessionEncoding {
+  read: 'sealed' | 'unsealed' | 'both';
+  write: 'sealed' | 'unsealed';
+}
+
+/**
  * AuthKit Configuration Options
  */
 export interface AuthKitConfig {
@@ -23,9 +37,10 @@ export interface AuthKitConfig {
   /**
    * The password used to encrypt the session cookie
    * Equivalent to the WORKOS_COOKIE_PASSWORD environment variable
-   * Must be at least 32 characters long
+   * Must be at least 32 characters long.
+   * Not required when sessionEncoding is fully unsealed ({ read: 'unsealed', write: 'unsealed' }).
    */
-  cookiePassword: string;
+  cookiePassword?: string;
 
   /**
    * The hostname of the API to use
@@ -67,6 +82,17 @@ export interface AuthKitConfig {
    * The domain for the session cookie
    */
   cookieDomain?: string;
+
+  /**
+   * Session encoding configuration.
+   * Controls whether sessions are sealed (iron-encrypted) or unsealed (base64url JSON).
+   * Use to migrate between formats without breaking existing sessions.
+   *
+   * Defaults to { read: 'sealed', write: 'sealed' } for backward compatibility.
+   *
+   * Environment variables: WORKOS_SESSION_ENCODING_READ, WORKOS_SESSION_ENCODING_WRITE
+   */
+  sessionEncoding?: SessionEncoding;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

- Adds a `sessionEncoding` config option to `AuthKitConfig` with independent `read` and `write` sub-options
- `read` accepts `'sealed'` | `'unsealed'` | `'both'` — the `'both'` mode tries sealed (iron-webcrypto) first, falls back to base64url JSON
- `write` accepts `'sealed'` | `'unsealed'` — unsealed writes base64url-encoded JSON instead of iron-encrypted data
- Defaults to `{ read: 'sealed', write: 'sealed' }` for full backward compatibility
- `cookiePassword` is now optional when encoding is fully unsealed (`read: 'unsealed'`, `write: 'unsealed'`)
- Supports env vars: `WORKOS_SESSION_ENCODING_READ` and `WORKOS_SESSION_ENCODING_WRITE`

### Migration phases (seal → unseal)

1. **Start**: `{ read: 'sealed', write: 'sealed' }` — current behavior, no changes needed
2. **Transition**: `{ read: 'both', write: 'unsealed' }` — accept old sealed cookies, write new unsealed format. Over time as users re-authenticate, their cookies migrate.
3. **Complete**: `{ read: 'unsealed', write: 'unsealed' }` — all sessions are unsealed, `cookiePassword` no longer required

The reverse direction works the same way — set `{ read: 'both', write: 'sealed' }` to re-seal sessions.

## Test plan

- [x] All 151 existing tests pass without modification
- [x] New tests cover all encoding mode combinations:
  - sealed → sealed (default behavior, backward compatible)
  - unsealed → unsealed (fully unsealed)
  - both → unsealed (migration: seal-to-unseal)
  - both → sealed (migration: unseal-to-seal)
  - Error paths for invalid data in each mode
- [x] TypeScript strict mode passes (`npx tsc --noEmit`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting passes (`pnpm run prettier`)
- [x] `cookiePassword` validation conditionally skipped when fully unsealed
- [x] Env var override tested for `WORKOS_SESSION_ENCODING_READ` / `WORKOS_SESSION_ENCODING_WRITE`

## Reviewer notes

- `AuthKitCore.ts` is at 316 lines (advisory limit is 300). The `encodeUnsealed`/`decodeUnsealed` helpers are already top-level functions outside the class. Could extract to a separate module in a follow-up.
- No manual Playwright testing — this is a pure TypeScript library with no UI. Unit tests are the authoritative verification mechanism.
- Teams adopting this feature should test `read: 'both'` mode with real cookies sealed by the previous iron-webcrypto version in their integration environment.