### PR TITLE
chore: migrate from Prettier to oxfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           pnpm install
 
-      - name: Prettier
+      - name: Format
         run: |
-          pnpm run prettier
+          pnpm run format:check
 
       # - name: Lint
       #   run: |

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 120,
+  "sortPackageJson": false,
+  "ignorePatterns": ["dist/", "node_modules/", "pnpm-lock.yaml", "coverage/"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-pnpm-lock.yaml
-package-lock.json

--- a/README.md
+++ b/README.md
@@ -49,15 +49,9 @@ configure({
 ### 2. Create Storage Adapter
 
 ```typescript
-import {
-  CookieSessionStorage,
-  parseCookieHeader,
-} from '@workos/authkit-session';
+import { CookieSessionStorage, parseCookieHeader } from '@workos/authkit-session';
 
-export class MyFrameworkStorage extends CookieSessionStorage<
-  Request,
-  Response
-> {
+export class MyFrameworkStorage extends CookieSessionStorage<Request, Response> {
   async getSession(request: Request): Promise<string | null> {
     const cookieHeader = request.headers.get('cookie');
     if (!cookieHeader) return null;
@@ -94,7 +88,7 @@ export class MyFrameworkStorage extends CookieSessionStorage<
 import { createAuthService } from '@workos/authkit-session';
 
 export const authService = createAuthService({
-  sessionStorageFactory: config => new MyFrameworkStorage(config),
+  sessionStorageFactory: (config) => new MyFrameworkStorage(config),
 });
 ```
 
@@ -102,10 +96,8 @@ export const authService = createAuthService({
 
 ```typescript
 export const authMiddleware = () => {
-  return createMiddleware().server(async args => {
-    const { auth, refreshedSessionData } = await authService.withAuth(
-      args.request,
-    );
+  return createMiddleware().server(async (args) => {
+    const { auth, refreshedSessionData } = await authService.withAuth(args.request);
 
     const result = await args.next({
       context: { auth: () => auth },
@@ -113,10 +105,7 @@ export const authMiddleware = () => {
 
     // CRITICAL: Persist refreshed tokens to cookie
     if (refreshedSessionData) {
-      const { headers } = await authService.saveSession(
-        undefined,
-        refreshedSessionData,
-      );
+      const { headers } = await authService.saveSession(undefined, refreshedSessionData);
       if (headers?.['Set-Cookie']) {
         const newResponse = new Response(result.response.body, {
           status: result.response.status,
@@ -195,12 +184,7 @@ authService.getSignUpUrl(options)
 For maximum control, use the primitives directly:
 
 ```typescript
-import {
-  AuthKitCore,
-  AuthOperations,
-  getWorkOS,
-  getConfigurationProvider,
-} from '@workos/authkit-session';
+import { AuthKitCore, AuthOperations, getWorkOS, getConfigurationProvider } from '@workos/authkit-session';
 
 const config = getConfigurationProvider();
 const client = getWorkOS(config.getConfig());

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "rebuild": "pnpm run clean && pnpm run build",
     "dev": "tsc -p tsconfig.build.json --watch",
     "prepack": "npm run rebuild",
-    "prettier": "prettier --check .",
-    "format": "prettier --write .",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/node": "^20.17.0",
     "@vitest/coverage-v8": "^4.0.17",
-    "prettier": "^3.7.4",
+    "oxfmt": "^0.42.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.17"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.17
         version: 4.0.17(vitest@4.0.17(@types/node@20.19.18))
-      prettier:
-        specifier: ^3.7.4
-        version: 3.7.4
+      oxfmt:
+        specifier: ^0.42.0
+        version: 0.42.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -222,6 +222,120 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@oxfmt/binding-android-arm-eabi@0.42.0':
+    resolution: {integrity: sha512-dsqPTYsozeokRjlrt/b4E7Pj0z3eS3Eg74TWQuuKbjY4VttBmA88rB7d50Xrd+TZ986qdXCNeZRPEzZHAe+jow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.42.0':
+    resolution: {integrity: sha512-t+aAjHxcr5eOBphFHdg1ouQU9qmZZoRxnX7UOJSaTwSoKsb6TYezNKO0YbWytGXCECObRqNcUxPoPr0KaraAIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.42.0':
+    resolution: {integrity: sha512-ulpSEYMKg61C5bRMZinFHrKJYRoKGVbvMEXA5zM1puX3O9T6Q4XXDbft20yrDijpYWeuG59z3Nabt+npeTsM1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.42.0':
+    resolution: {integrity: sha512-ttxLKhQYPdFiM8I/Ri37cvqChE4Xa562nNOsZFcv1CKTVLeEozXjKuYClNvxkXmNlcF55nzM80P+CQkdFBu+uQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.42.0':
+    resolution: {integrity: sha512-Og7QS3yI3tdIKYZ58SXik0rADxIk2jmd+/YvuHRyKULWpG4V2fR5V4hvKm624Mc0cQET35waPXiCQWvjQEjwYQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
+    resolution: {integrity: sha512-jwLOw/3CW4H6Vxcry4/buQHk7zm9Ne2YsidzTL1kpiMe4qqrRCwev3dkyWe2YkFmP+iZCQ7zku4KwjcLRoh8ew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
+    resolution: {integrity: sha512-XwXu2vkMtiq2h7tfvN+WA/9/5/1IoGAVCFPiiQUvcAuG3efR97KNcRGM8BetmbYouFotQ2bDal3yyjUx6IPsTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
+    resolution: {integrity: sha512-ea7s/XUJoT7ENAtUQDudFe3nkSM3e3Qpz4nJFRdzO2wbgXEcjnchKLEsV3+t4ev3r8nWxIYr9NRjPWtnyIFJVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.42.0':
+    resolution: {integrity: sha512-+JA0YMlSdDqmacygGi2REp57c3fN+tzARD8nwsukx9pkCHK+6DkbAA9ojS4lNKsiBjIW8WWa0pBrBWhdZEqfuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
+    resolution: {integrity: sha512-VfnET0j4Y5mdfCzh5gBt0NK28lgn5DKx+8WgSMLYYeSooHhohdbzwAStLki9pNuGy51y4I7IoW8bqwAaCMiJQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
+    resolution: {integrity: sha512-gVlCbmBkB0fxBWbhBj9rcxezPydsQHf4MFKeHoTSPicOQ+8oGeTQgQ8EeesSybWeiFPVRx3bgdt4IJnH6nOjAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
+    resolution: {integrity: sha512-zN5OfstL0avgt/IgvRu0zjQzVh/EPkcLzs33E9LMAzpqlLWiPWeMDZyMGFlSRGOdDjuNmlZBCgj0pFnK5u32TQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
+    resolution: {integrity: sha512-9X6+H2L0qMc2sCAgO9HS03bkGLMKvOFjmEdchaFlany3vNZOjnVui//D8k/xZAtQv2vaCs1reD5KAgPoIU4msA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.42.0':
+    resolution: {integrity: sha512-BajxJ6KQvMMdpXGPWhBGyjb2Jvx4uec0w+wi6TJZ6Tv7+MzPwe0pO8g5h1U0jyFgoaF7mDl6yKPW3ykWcbUJRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.42.0':
+    resolution: {integrity: sha512-0wV284I6vc5f0AqAhgAbHU2935B4bVpncPoe5n/WzVZY/KnHgqxC8iSFGeSyLWEgstFboIcWkOPck7tqbdHkzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.42.0':
+    resolution: {integrity: sha512-p4BG6HpGnhfgHk1rzZfyR6zcWkE7iLrWxyehHfXUy4Qa5j3e0roglFOdP/Nj5cJJ58MA3isQ5dlfkW2nNEpolw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
+    resolution: {integrity: sha512-mn//WV60A+IetORDxYieYGAoQso4KnVRRjORDewMcod4irlRe0OSC7YPhhwaexYNPQz/GCFk+v9iUcZ2W22yxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
+    resolution: {integrity: sha512-3gWltUrvuz4LPJXWivoAxZ28Of2O4N7OGuM5/X3ubPXCEV8hmgECLZzjz7UYvSDUS3grfdccQwmjynm+51EFpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.42.0':
+    resolution: {integrity: sha512-Wg4TMAfQRL9J9AZevJ/ZNy3uyyDztDYQtGr4P8UyyzIhLhFrdSmz1J/9JT+rv0fiCDLaFOBQnj3f3K3+a5PzDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/rollup-android-arm-eabi@4.52.3':
     resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
@@ -472,6 +586,11 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oxfmt@0.42.0:
+    resolution: {integrity: sha512-QhejGErLSMReNuZ6vxgFHDyGoPbjTRNi6uGHjy0cvIjOQFqD6xmr/T+3L41ixR3NIgzcNiJ6ylQKpvShTgDfqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -485,11 +604,6 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   rollup@4.52.3:
     resolution: {integrity: sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==}
@@ -528,6 +642,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -727,6 +845,63 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@oxfmt/binding-android-arm-eabi@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.42.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.52.3':
     optional: true
@@ -961,6 +1136,30 @@ snapshots:
 
   obug@2.1.1: {}
 
+  oxfmt@0.42.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.42.0
+      '@oxfmt/binding-android-arm64': 0.42.0
+      '@oxfmt/binding-darwin-arm64': 0.42.0
+      '@oxfmt/binding-darwin-x64': 0.42.0
+      '@oxfmt/binding-freebsd-x64': 0.42.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.42.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.42.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.42.0
+      '@oxfmt/binding-linux-arm64-musl': 0.42.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.42.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.42.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.42.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.42.0
+      '@oxfmt/binding-linux-x64-gnu': 0.42.0
+      '@oxfmt/binding-linux-x64-musl': 0.42.0
+      '@oxfmt/binding-openharmony-arm64': 0.42.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.42.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.42.0
+      '@oxfmt/binding-win32-x64-msvc': 0.42.0
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -972,8 +1171,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prettier@3.7.4: {}
 
   rollup@4.52.3:
     dependencies:
@@ -1025,6 +1222,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,0 @@
-/** @type {import('prettier').Config} */
-export default {
-  trailingComma: 'all',
-  semi: true,
-  arrowParens: 'avoid',
-  useTabs: false,
-  tabWidth: 2,
-  singleQuote: true,
-};

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -48,11 +48,7 @@ describe('AuthKitCore', () => {
   let core: AuthKitCore;
 
   beforeEach(() => {
-    core = new AuthKitCore(
-      mockConfig as any,
-      mockClient as any,
-      mockEncryption as any,
-    );
+    core = new AuthKitCore(mockConfig as any, mockClient as any, mockEncryption as any);
   });
 
   describe('constructor', () => {
@@ -74,9 +70,7 @@ describe('AuthKitCore', () => {
     });
 
     it('throws error for invalid JWT', () => {
-      expect(() => core.parseTokenClaims('invalid-jwt')).toThrow(
-        'Invalid token',
-      );
+      expect(() => core.parseTokenClaims('invalid-jwt')).toThrow('Invalid token');
     });
 
     it('supports custom claims', () => {
@@ -119,8 +113,7 @@ describe('AuthKitCore', () => {
     });
 
     it('returns false when token has no expiry', () => {
-      const noExpiryJwt =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
+      const noExpiryJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
 
       const result = core.isTokenExpiring(noExpiryJwt);
 
@@ -163,11 +156,7 @@ describe('AuthKitCore', () => {
         },
         unsealData: async () => ({}),
       };
-      const failingCore = new AuthKitCore(
-        mockConfig as any,
-        mockClient as any,
-        failingEncryption as any,
-      );
+      const failingCore = new AuthKitCore(mockConfig as any, mockClient as any, failingEncryption as any);
 
       await expect(
         failingCore.encryptSession({
@@ -195,15 +184,9 @@ describe('AuthKitCore', () => {
           throw new Error('Decryption failed');
         },
       };
-      const failingCore = new AuthKitCore(
-        mockConfig as any,
-        mockClient as any,
-        failingEncryption as any,
-      );
+      const failingCore = new AuthKitCore(mockConfig as any, mockClient as any, failingEncryption as any);
 
-      await expect(failingCore.decryptSession('bad-data')).rejects.toThrow(
-        SessionEncryptionError,
-      );
+      await expect(failingCore.decryptSession('bad-data')).rejects.toThrow(SessionEncryptionError);
     });
   });
 
@@ -228,11 +211,7 @@ describe('AuthKitCore', () => {
           }),
         },
       };
-      const testCore = new AuthKitCore(
-        mockConfig as any,
-        clientWithSpy as any,
-        mockEncryption as any,
-      );
+      const testCore = new AuthKitCore(mockConfig as any, clientWithSpy as any, mockEncryption as any);
 
       const result = await testCore.refreshTokens('refresh-token', 'org_123');
 
@@ -248,15 +227,9 @@ describe('AuthKitCore', () => {
           },
         },
       };
-      const failingCore = new AuthKitCore(
-        mockConfig as any,
-        failingClient as any,
-        mockEncryption as any,
-      );
+      const failingCore = new AuthKitCore(mockConfig as any, failingClient as any, mockEncryption as any);
 
-      await expect(failingCore.refreshTokens('bad-token')).rejects.toThrow(
-        TokenRefreshError,
-      );
+      await expect(failingCore.refreshTokens('bad-token')).rejects.toThrow(TokenRefreshError);
     });
   });
 });

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -3,12 +3,7 @@ import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { once } from '../utils.js';
 import type { AuthKitConfig } from './config/types.js';
 import { SessionEncryptionError, TokenRefreshError } from './errors.js';
-import type {
-  BaseTokenClaims,
-  CustomClaims,
-  Session,
-  SessionEncryption,
-} from './session/types.js';
+import type { BaseTokenClaims, CustomClaims, Session, SessionEncryption } from './session/types.js';
 
 /**
  * AuthKitCore provides pure business logic for authentication operations.
@@ -29,11 +24,7 @@ export class AuthKitCore {
   private encryption: SessionEncryption;
   private clientId: string;
 
-  constructor(
-    config: AuthKitConfig,
-    client: WorkOS,
-    encryption: SessionEncryption,
-  ) {
+  constructor(config: AuthKitConfig, client: WorkOS, encryption: SessionEncryption) {
     this.config = config;
     this.client = client;
     this.encryption = encryption;
@@ -44,9 +35,7 @@ export class AuthKitCore {
    * JWKS public key fetcher - cached for performance
    */
   private readonly getPublicKey = once(() =>
-    createRemoteJWKSet(
-      new URL(this.client.userManagement.getJwksUrl(this.clientId)),
-    ),
+    createRemoteJWKSet(new URL(this.client.userManagement.getJwksUrl(this.clientId))),
   );
 
   /**
@@ -99,9 +88,7 @@ export class AuthKitCore {
    * @returns Decoded token claims
    * @throws Error if token is invalid
    */
-  parseTokenClaims<TCustomClaims = CustomClaims>(
-    token: string,
-  ): BaseTokenClaims & TCustomClaims {
+  parseTokenClaims<TCustomClaims = CustomClaims>(token: string): BaseTokenClaims & TCustomClaims {
     try {
       return decodeJwt<BaseTokenClaims & TCustomClaims>(token);
     } catch (error) {
@@ -137,10 +124,9 @@ export class AuthKitCore {
    */
   async decryptSession(encryptedSession: string): Promise<Session> {
     try {
-      const session = await this.encryption.unsealData<Session>(
-        encryptedSession,
-        { password: this.config.cookiePassword },
-      );
+      const session = await this.encryption.unsealData<Session>(encryptedSession, {
+        password: this.config.cookiePassword,
+      });
       return session;
     } catch (error) {
       throw new SessionEncryptionError('Failed to decrypt session', error);
@@ -167,12 +153,11 @@ export class AuthKitCore {
     impersonator: Impersonator | undefined;
   }> {
     try {
-      const result =
-        await this.client.userManagement.authenticateWithRefreshToken({
-          refreshToken,
-          clientId: this.clientId,
-          organizationId,
-        });
+      const result = await this.client.userManagement.authenticateWithRefreshToken({
+        refreshToken,
+        clientId: this.clientId,
+        organizationId,
+      });
 
       return {
         accessToken: result.accessToken,
@@ -236,14 +221,11 @@ export class AuthKitCore {
       // Token parsing failed - continue without session context
     }
 
-    const newSession = await this.refreshTokens(
-      session.refreshToken,
-      organizationId,
-      { userId: session.user?.id, sessionId },
-    );
-    const newClaims = this.parseTokenClaims<TCustomClaims>(
-      newSession.accessToken,
-    );
+    const newSession = await this.refreshTokens(session.refreshToken, organizationId, {
+      userId: session.user?.id,
+      sessionId,
+    });
+    const newClaims = this.parseTokenClaims<TCustomClaims>(newSession.accessToken);
     return {
       valid: true,
       refreshed: true,

--- a/src/core/client/types.ts
+++ b/src/core/client/types.ts
@@ -1,12 +1,8 @@
 import type { User, Impersonator, WorkOS } from '@workos-inc/node';
 export interface UserManagementInterface {
   getAuthorizationUrl: (options: AuthorizationURLOptions) => string;
-  authenticateWithCode: (
-    options: AuthenticateWithCodeOptions,
-  ) => Promise<AuthenticationResponse>;
-  authenticateWithRefreshToken: (
-    options: AuthenticateWithRefreshTokenOptions,
-  ) => Promise<AuthenticationResponse>;
+  authenticateWithCode: (options: AuthenticateWithCodeOptions) => Promise<AuthenticationResponse>;
+  authenticateWithRefreshToken: (options: AuthenticateWithRefreshTokenOptions) => Promise<AuthenticationResponse>;
   getLogoutUrl: (options: { sessionId: string; returnTo?: string }) => string;
   revokeSession: (options: { sessionId: string }) => Promise<void>;
 }

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -1,11 +1,5 @@
 import { vi } from 'vitest';
-import {
-  configure,
-  getConfig,
-  getConfigurationProvider,
-  getFullConfig,
-  validateConfig,
-} from './config.js';
+import { configure, getConfig, getConfigurationProvider, getFullConfig, validateConfig } from './config.js';
 import { ConfigurationProvider } from './config/ConfigurationProvider.js';
 
 describe('config', () => {
@@ -64,9 +58,7 @@ describe('config', () => {
     });
 
     it('throws for missing required config', () => {
-      expect(() => getConfig('clientId')).toThrow(
-        'Missing required configuration value for clientId',
-      );
+      expect(() => getConfig('clientId')).toThrow('Missing required configuration value for clientId');
     });
 
     it('returns defaults for optional config', () => {
@@ -77,10 +69,7 @@ describe('config', () => {
     it('prefers environment over config', () => {
       const envValue = 'env-client-id';
       const validPassword = 'a'.repeat(32);
-      configure(
-        { clientId: 'config-client-id', cookiePassword: validPassword },
-        () => envValue,
-      );
+      configure({ clientId: 'config-client-id', cookiePassword: validPassword }, () => envValue);
 
       expect(getConfig('clientId')).toBe(envValue);
     });
@@ -124,18 +113,14 @@ describe('config', () => {
     });
 
     it('throws with batch of missing fields', () => {
-      expect(() => validateConfig()).toThrow(
-        /AuthKit configuration error\. Missing or invalid environment variables/,
-      );
+      expect(() => validateConfig()).toThrow(/AuthKit configuration error\. Missing or invalid environment variables/);
     });
 
     it('shows all missing fields at once', () => {
       expect(() => validateConfig()).toThrow(/WORKOS_CLIENT_ID is required/);
       expect(() => validateConfig()).toThrow(/WORKOS_API_KEY is required/);
       expect(() => validateConfig()).toThrow(/WORKOS_REDIRECT_URI is required/);
-      expect(() => validateConfig()).toThrow(
-        /WORKOS_COOKIE_PASSWORD is required/,
-      );
+      expect(() => validateConfig()).toThrow(/WORKOS_COOKIE_PASSWORD is required/);
     });
 
     it('throws for short cookie password', () => {
@@ -146,9 +131,7 @@ describe('config', () => {
         cookiePassword: 'short',
       });
 
-      expect(() => validateConfig()).toThrow(
-        /WORKOS_COOKIE_PASSWORD must be at least 32 characters \(currently 5\)/,
-      );
+      expect(() => validateConfig()).toThrow(/WORKOS_COOKIE_PASSWORD must be at least 32 characters \(currently 5\)/);
     });
 
     it('includes dashboard link in error', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -35,14 +35,8 @@ export function configure(config: Partial<AuthKitConfig>): void;
  *   clientId: 'your-client-id',
  * }, env);
  */
-export function configure(
-  config: Partial<AuthKitConfig>,
-  source: ValueSource,
-): void;
-export function configure(
-  configOrSource: Partial<AuthKitConfig> | ValueSource,
-  source?: ValueSource,
-): void {
+export function configure(config: Partial<AuthKitConfig>, source: ValueSource): void;
+export function configure(configOrSource: Partial<AuthKitConfig> | ValueSource, source?: ValueSource): void {
   getConfigurationInstance().configure(configOrSource, source);
 }
 
@@ -54,9 +48,7 @@ export function configure(
  * @param key The configuration key
  * @returns The configuration value
  */
-export function getConfig<K extends keyof AuthKitConfig>(
-  key: K,
-): AuthKitConfig[K] {
+export function getConfig<K extends keyof AuthKitConfig>(key: K): AuthKitConfig[K] {
   return getConfigurationInstance().getValue(key);
 }
 

--- a/src/core/config/ConfigurationProvider.spec.ts
+++ b/src/core/config/ConfigurationProvider.spec.ts
@@ -82,15 +82,9 @@ describe('ConfigurationProvider', () => {
 
   describe('getEnvironmentVariableName()', () => {
     it('converts camelCase to SCREAMING_SNAKE_CASE', () => {
-      expect(provider['getEnvironmentVariableName']('clientId')).toBe(
-        'WORKOS_CLIENT_ID',
-      );
-      expect(provider['getEnvironmentVariableName']('apiPort')).toBe(
-        'WORKOS_API_PORT',
-      );
-      expect(provider['getEnvironmentVariableName']('cookieMaxAge')).toBe(
-        'WORKOS_COOKIE_MAX_AGE',
-      );
+      expect(provider['getEnvironmentVariableName']('clientId')).toBe('WORKOS_CLIENT_ID');
+      expect(provider['getEnvironmentVariableName']('apiPort')).toBe('WORKOS_API_PORT');
+      expect(provider['getEnvironmentVariableName']('cookieMaxAge')).toBe('WORKOS_COOKIE_MAX_AGE');
     });
   });
 
@@ -180,9 +174,7 @@ describe('ConfigurationProvider', () => {
       const error = () => provider.validate();
       expect(error).toThrow(/WORKOS_API_KEY is required/);
       expect(error).toThrow(/WORKOS_REDIRECT_URI is required/);
-      expect(error).toThrow(
-        /WORKOS_COOKIE_PASSWORD must be at least 32 characters/,
-      );
+      expect(error).toThrow(/WORKOS_COOKIE_PASSWORD must be at least 32 characters/);
     });
 
     it('prefers environment values over config in validation', () => {
@@ -190,8 +182,7 @@ describe('ConfigurationProvider', () => {
         if (key === 'WORKOS_COOKIE_PASSWORD') return 'a'.repeat(32);
         if (key === 'WORKOS_CLIENT_ID') return 'env-client';
         if (key === 'WORKOS_API_KEY') return 'env-api-key';
-        if (key === 'WORKOS_REDIRECT_URI')
-          return 'http://localhost:3000/callback';
+        if (key === 'WORKOS_REDIRECT_URI') return 'http://localhost:3000/callback';
         return undefined;
       });
       provider.configure(source);

--- a/src/core/config/ConfigurationProvider.ts
+++ b/src/core/config/ConfigurationProvider.ts
@@ -6,8 +6,7 @@ import type { AuthKitConfig, ValueSource } from './types.js';
 const defaultSource: ValueSource = (key: string): string | undefined => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const processEnv: Record<string, string> | undefined = (globalThis as any)
-      ?.process?.env;
+    const processEnv: Record<string, string> | undefined = (globalThis as any)?.process?.env;
     return processEnv?.[key];
   } catch {
     return undefined;
@@ -33,12 +32,7 @@ export class ConfigurationProvider {
 
   private valueSource: ValueSource = defaultSource;
 
-  private readonly requiredKeys: (keyof AuthKitConfig)[] = [
-    'clientId',
-    'apiKey',
-    'redirectUri',
-    'cookiePassword',
-  ];
+  private readonly requiredKeys: (keyof AuthKitConfig)[] = ['clientId', 'apiKey', 'redirectUri', 'cookiePassword'];
 
   /**
    * Convert a camelCase string to an uppercase, underscore-separated environment variable name.
@@ -57,10 +51,7 @@ export class ConfigurationProvider {
     this.valueSource = source;
   }
 
-  configure(
-    configOrSource: Partial<AuthKitConfig> | ValueSource,
-    source?: ValueSource,
-  ): void {
+  configure(configOrSource: Partial<AuthKitConfig> | ValueSource, source?: ValueSource): void {
     if (typeof configOrSource === 'function') {
       this.setValueSource(configOrSource);
     } else if (typeof configOrSource === 'object' && !source) {
@@ -83,9 +74,7 @@ export class ConfigurationProvider {
     }
 
     if (this.requiredKeys.includes(key)) {
-      throw new Error(
-        `Missing required configuration value for ${key} (${envKey}).`,
-      );
+      throw new Error(`Missing required configuration value for ${key} (${envKey}).`);
     }
 
     return undefined as AuthKitConfig[K];
@@ -105,10 +94,7 @@ export class ConfigurationProvider {
     return undefined;
   }
 
-  private convertValueType<K extends keyof AuthKitConfig>(
-    key: K,
-    value: unknown,
-  ): AuthKitConfig[K] | undefined {
+  private convertValueType<K extends keyof AuthKitConfig>(key: K, value: unknown): AuthKitConfig[K] | undefined {
     if (typeof value !== 'string') {
       return value as AuthKitConfig[K];
     }
@@ -159,9 +145,7 @@ export class ConfigurationProvider {
         // Special validation for cookiePassword length
         const password = String(value);
         if (password.length < 32) {
-          errors.push(
-            `${envKey} must be at least 32 characters (currently ${password.length})`,
-          );
+          errors.push(`${envKey} must be at least 32 characters (currently ${password.length})`);
         }
       }
     }
@@ -169,7 +153,7 @@ export class ConfigurationProvider {
     if (errors.length > 0) {
       throw new Error(
         'AuthKit configuration error. Missing or invalid environment variables:\n\n' +
-          errors.map(e => `  • ${e}`).join('\n') +
+          errors.map((e) => `  • ${e}`).join('\n') +
           '\n\nSet these environment variables or call configure() with the required values.' +
           '\nGet your values from the WorkOS Dashboard: https://dashboard.workos.com',
       );

--- a/src/core/encryption/ironWebcryptoEncryption.spec.ts
+++ b/src/core/encryption/ironWebcryptoEncryption.spec.ts
@@ -45,9 +45,7 @@ describe('ironWebcryptoEncryption', () => {
       });
       const wrongPassword = 'wrong-password-that-is-32-chars!!';
 
-      await expect(
-        encryption.unsealData(sealed, { password: wrongPassword }),
-      ).rejects.toThrow();
+      await expect(encryption.unsealData(sealed, { password: wrongPassword })).rejects.toThrow();
     });
 
     it('unseals tokens without version suffix (v1 format)', async () => {

--- a/src/core/encryption/ironWebcryptoEncryption.ts
+++ b/src/core/encryption/ironWebcryptoEncryption.ts
@@ -13,19 +13,13 @@ export class SessionEncryption implements SessionEncryptionInterface {
     sealWithoutVersion: string;
     tokenVersion: number | null;
   } {
-    const [sealWithoutVersion = '', tokenVersionAsString] = seal.split(
-      this.versionDelimiter,
-    );
-    const tokenVersion =
-      tokenVersionAsString == null ? null : parseInt(tokenVersionAsString, 10);
+    const [sealWithoutVersion = '', tokenVersionAsString] = seal.split(this.versionDelimiter);
+    const tokenVersion = tokenVersionAsString == null ? null : parseInt(tokenVersionAsString, 10);
     return { sealWithoutVersion, tokenVersion };
   }
 
   // Encrypt data in a way that's compatible with iron-session
-  async sealData(
-    data: unknown,
-    { password, ttl = 0 }: { password: string; ttl?: number | undefined },
-  ) {
+  async sealData(data: unknown, { password, ttl = 0 }: { password: string; ttl?: number | undefined }) {
     // Format password as iron-session expects
     const passwordObj = {
       id: '1',
@@ -56,10 +50,7 @@ export class SessionEncryption implements SessionEncryptionInterface {
   }
 
   // Decrypt data from iron-session with HMAC verification
-  async unsealData<T = unknown>(
-    encryptedData: string,
-    { password }: { password: string },
-  ): Promise<T> {
+  async unsealData<T = unknown>(encryptedData: string, { password }: { password: string }): Promise<T> {
     // First, parse the seal to extract the version
     const { sealWithoutVersion, tokenVersion } = this.parseSeal(encryptedData);
 

--- a/src/core/errors.spec.ts
+++ b/src/core/errors.spec.ts
@@ -1,9 +1,4 @@
-import {
-  AuthKitError,
-  SessionEncryptionError,
-  TokenValidationError,
-  TokenRefreshError,
-} from './errors.js';
+import { AuthKitError, SessionEncryptionError, TokenValidationError, TokenRefreshError } from './errors.js';
 
 describe('AuthKitError', () => {
   it('creates error with message', () => {
@@ -50,10 +45,7 @@ describe('SessionEncryptionError', () => {
 
   it('creates error with cause', () => {
     const originalError = new Error('Crypto error');
-    const error = new SessionEncryptionError(
-      'Encryption failed',
-      originalError,
-    );
+    const error = new SessionEncryptionError('Encryption failed', originalError);
 
     expect(error.cause).toBe(originalError);
   });
@@ -168,7 +160,7 @@ describe('error inheritance', () => {
       new TokenRefreshError('test'),
     ];
 
-    errors.forEach(error => {
+    errors.forEach((error) => {
       expect(() => {
         throw error;
       }).toThrow(AuthKitError);

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -27,11 +27,7 @@ export class TokenRefreshError extends AuthKitError {
   readonly userId?: string;
   readonly sessionId?: string;
 
-  constructor(
-    message: string,
-    cause?: unknown,
-    context?: { userId?: string; sessionId?: string },
-  ) {
+  constructor(message: string, cause?: unknown, context?: { userId?: string; sessionId?: string }) {
     super(message, cause);
     this.name = 'TokenRefreshError';
     this.userId = context?.userId;

--- a/src/core/session/CookieSessionStorage.spec.ts
+++ b/src/core/session/CookieSessionStorage.spec.ts
@@ -2,9 +2,7 @@ import { CookieSessionStorage } from './CookieSessionStorage.js';
 import type { AuthKitConfig } from '../config/types.js';
 
 // Mock config
-const createMockConfig = (
-  overrides: Partial<AuthKitConfig> = {},
-): AuthKitConfig => ({
+const createMockConfig = (overrides: Partial<AuthKitConfig> = {}): AuthKitConfig => ({
   clientId: 'test-client-id',
   apiKey: 'test-api-key',
   redirectUri: 'https://example.com/callback',

--- a/src/core/session/CookieSessionStorage.ts
+++ b/src/core/session/CookieSessionStorage.ts
@@ -13,10 +13,7 @@ export interface CookieOptions {
   partitioned?: boolean;
 }
 
-export abstract class CookieSessionStorage<
-  TRequest,
-  TResponse,
-> implements SessionStorage<TRequest, TResponse> {
+export abstract class CookieSessionStorage<TRequest, TResponse> implements SessionStorage<TRequest, TResponse> {
   protected cookieName: string;
   protected readonly cookieOptions: CookieOptions;
 
@@ -63,8 +60,7 @@ export abstract class CookieSessionStorage<
     if (o.httpOnly) a.push('HttpOnly');
     if (o.secure) a.push('Secure');
     if (o.sameSite) {
-      const capitalizedSameSite =
-        o.sameSite.charAt(0).toUpperCase() + o.sameSite.slice(1).toLowerCase();
+      const capitalizedSameSite = o.sameSite.charAt(0).toUpperCase() + o.sameSite.slice(1).toLowerCase();
       a.push(`SameSite=${capitalizedSameSite}`);
     }
     if (o.priority) a.push(`Priority=${o.priority}`);
@@ -83,9 +79,7 @@ export abstract class CookieSessionStorage<
     return mutated ?? { headers: { 'Set-Cookie': header } };
   }
 
-  async clearSession(
-    response: TResponse,
-  ): Promise<{ response?: TResponse; headers?: HeadersBag }> {
+  async clearSession(response: TResponse): Promise<{ response?: TResponse; headers?: HeadersBag }> {
     const header = this.buildSetCookie('', true);
     const mutated = await this.applyHeaders(response, { 'Set-Cookie': header });
     return mutated ?? { headers: { 'Set-Cookie': header } };

--- a/src/core/session/TokenManager.spec.ts
+++ b/src/core/session/TokenManager.spec.ts
@@ -34,15 +34,11 @@ describe('TokenManager', () => {
     });
 
     it('throws error for invalid JWT', () => {
-      expect(() => tokenManager.parseTokenClaims('invalid-jwt')).toThrow(
-        'Invalid token',
-      );
+      expect(() => tokenManager.parseTokenClaims('invalid-jwt')).toThrow('Invalid token');
     });
 
     it('throws error for malformed JWT', () => {
-      expect(() => tokenManager.parseTokenClaims('not.a.jwt')).toThrow(
-        'Invalid token',
-      );
+      expect(() => tokenManager.parseTokenClaims('not.a.jwt')).toThrow('Invalid token');
     });
 
     it('supports custom claims', () => {
@@ -50,9 +46,7 @@ describe('TokenManager', () => {
       const customJwt =
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsImN1c3RvbUZpZWxkIjoiY3VzdG9tLXZhbHVlIn0.fake-signature';
 
-      const result = tokenManager.parseTokenClaims<{ customField: string }>(
-        customJwt,
-      );
+      const result = tokenManager.parseTokenClaims<{ customField: string }>(customJwt);
 
       expect(result.customField).toBe('custom-value');
     });
@@ -69,8 +63,7 @@ describe('TokenManager', () => {
     });
 
     it('returns null when token has no exp claim', () => {
-      const jwtWithoutExp =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
+      const jwtWithoutExp = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
 
       const result = tokenManager.getTokenExpiryTime(jwtWithoutExp);
 
@@ -107,8 +100,7 @@ describe('TokenManager', () => {
     });
 
     it('returns false when token has no expiry', () => {
-      const noExpiryJwt =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
+      const noExpiryJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.fake-signature';
 
       const result = tokenManager.isTokenExpiring(noExpiryJwt);
 

--- a/src/core/session/TokenManager.ts
+++ b/src/core/session/TokenManager.ts
@@ -13,9 +13,7 @@ export class TokenManager {
   }
 
   private readonly getPublicKey = once(() =>
-    createRemoteJWKSet(
-      new URL(this.client.userManagement.getJwksUrl(this.clientId)),
-    ),
+    createRemoteJWKSet(new URL(this.client.userManagement.getJwksUrl(this.clientId))),
   );
 
   async verifyToken(token: string): Promise<boolean> {
@@ -27,9 +25,7 @@ export class TokenManager {
     }
   }
 
-  parseTokenClaims<TCustomClaims = CustomClaims>(
-    token: string,
-  ): BaseTokenClaims & TCustomClaims {
+  parseTokenClaims<TCustomClaims = CustomClaims>(token: string): BaseTokenClaims & TCustomClaims {
     try {
       return decodeJwt<BaseTokenClaims & TCustomClaims>(token);
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,12 +45,7 @@ export { default as sessionEncryption } from './core/encryption/ironWebcryptoEnc
 // ============================================
 // Configuration
 // ============================================
-export {
-  configure,
-  getConfig,
-  getConfigurationProvider,
-  validateConfig,
-} from './core/config.js';
+export { configure, getConfig, getConfigurationProvider, validateConfig } from './core/config.js';
 export { ConfigurationProvider } from './core/config/ConfigurationProvider.js';
 
 // ============================================
@@ -61,22 +56,11 @@ export { getWorkOS } from './core/client/workos.js';
 // ============================================
 // Errors
 // ============================================
-export {
-  AuthKitError,
-  SessionEncryptionError,
-  TokenValidationError,
-  TokenRefreshError,
-} from './core/errors.js';
+export { AuthKitError, SessionEncryptionError, TokenValidationError, TokenRefreshError } from './core/errors.js';
 
 // ============================================
 // Type Exports
 // ============================================
 export * from './core/session/types.js';
 export * from './core/config/types.js';
-export type {
-  User,
-  Impersonator,
-  Organization,
-  WorkOS,
-  AuthenticationResponse,
-} from '@workos-inc/node';
+export type { User, Impersonator, Organization, WorkOS, AuthenticationResponse } from '@workos-inc/node';

--- a/src/operations/AuthOperations.spec.ts
+++ b/src/operations/AuthOperations.spec.ts
@@ -55,11 +55,7 @@ describe('AuthOperations', () => {
   let operations: AuthOperations;
 
   beforeEach(() => {
-    operations = new AuthOperations(
-      mockCore as any,
-      mockClient as any,
-      mockConfig as any,
-    );
+    operations = new AuthOperations(mockCore as any, mockClient as any, mockConfig as any);
   });
 
   describe('constructor', () => {
@@ -146,11 +142,7 @@ describe('AuthOperations', () => {
         },
         encryptSession: async () => 'encrypted-session-data',
       };
-      const testOps = new AuthOperations(
-        coreWithSpy as any,
-        mockClient as any,
-        mockConfig as any,
-      );
+      const testOps = new AuthOperations(coreWithSpy as any, mockClient as any, mockConfig as any);
 
       const session = {
         accessToken: 'test-token',
@@ -191,11 +183,7 @@ describe('AuthOperations', () => {
         },
         encryptSession: async () => 'encrypted-session-data',
       };
-      const testOps = new AuthOperations(
-        coreWithSpy as any,
-        mockClient as any,
-        mockConfig as any,
-      );
+      const testOps = new AuthOperations(coreWithSpy as any, mockClient as any, mockConfig as any);
 
       const session = {
         accessToken: 'test-token',

--- a/src/operations/AuthOperations.ts
+++ b/src/operations/AuthOperations.ts
@@ -1,11 +1,7 @@
 import type { WorkOS } from '@workos-inc/node';
 import type { AuthKitCore } from '../core/AuthKitCore.js';
 import type { AuthKitConfig } from '../core/config/types.js';
-import type {
-  AuthResult,
-  GetAuthorizationUrlOptions,
-  Session,
-} from '../core/session/types.js';
+import type { AuthResult, GetAuthorizationUrlOptions, Session } from '../core/session/types.js';
 
 /**
  * AuthOperations provides high-level authentication operations.
@@ -86,10 +82,10 @@ export class AuthOperations {
     encryptedSession: string;
   }> {
     // Force refresh via core, optionally switching organizations
-    const { session: newSession, claims } = await this.core.validateAndRefresh(
-      session,
-      { force: true, organizationId },
-    );
+    const { session: newSession, claims } = await this.core.validateAndRefresh(session, {
+      force: true,
+      organizationId,
+    });
 
     const encryptedSession = await this.core.encryptSession(newSession);
 
@@ -124,9 +120,7 @@ export class AuthOperations {
    * @param options - Authorization URL options (returnPathname, screenHint, state, etc.)
    * @returns The authorization URL
    */
-  async getAuthorizationUrl(
-    options: GetAuthorizationUrlOptions = {},
-  ): Promise<string> {
+  async getAuthorizationUrl(options: GetAuthorizationUrlOptions = {}): Promise<string> {
     // Build the combined state parameter (matches authkit-nextjs format)
     const internalState = options.returnPathname
       ? btoa(JSON.stringify({ returnPathname: options.returnPathname }))
@@ -156,9 +150,7 @@ export class AuthOperations {
   /**
    * Convenience method: Get sign-in URL.
    */
-  async getSignInUrl(
-    options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {},
-  ): Promise<string> {
+  async getSignInUrl(options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {}): Promise<string> {
     return this.getAuthorizationUrl({
       ...options,
       screenHint: 'sign-in',
@@ -168,9 +160,7 @@ export class AuthOperations {
   /**
    * Convenience method: Get sign-up URL.
    */
-  async getSignUpUrl(
-    options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {},
-  ): Promise<string> {
+  async getSignUpUrl(options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {}): Promise<string> {
     return this.getAuthorizationUrl({
       ...options,
       screenHint: 'sign-up',

--- a/src/service/AuthService.spec.ts
+++ b/src/service/AuthService.spec.ts
@@ -43,8 +43,7 @@ const mockClient = {
       user: mockUser,
       impersonator: undefined,
     }),
-    getLogoutUrl: ({ sessionId }: any) =>
-      `https://api.workos.com/sso/logout?session_id=${sessionId}`,
+    getLogoutUrl: ({ sessionId }: any) => `https://api.workos.com/sso/logout?session_id=${sessionId}`,
   },
 };
 
@@ -62,12 +61,7 @@ describe('AuthService', () => {
   let service: AuthService<any, any>;
 
   beforeEach(() => {
-    service = new AuthService(
-      mockConfig as any,
-      mockStorage as any,
-      mockClient as any,
-      mockEncryption as any,
-    );
+    service = new AuthService(mockConfig as any, mockStorage as any, mockClient as any, mockEncryption as any);
   });
 
   describe('constructor', () => {

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -70,10 +70,9 @@ export class AuthService<TRequest, TResponse> {
         return { auth: { user: null } };
       }
 
-      const { claims, session, refreshed } =
-        await this.core.validateAndRefresh<TCustomClaims>(
-          await this.core.decryptSession(encryptedSession),
-        );
+      const { claims, session, refreshed } = await this.core.validateAndRefresh<TCustomClaims>(
+        await this.core.decryptSession(encryptedSession),
+      );
 
       const auth: AuthResult<TCustomClaims> = {
         refreshToken: session.refreshToken,
@@ -135,9 +134,7 @@ export class AuthService<TRequest, TResponse> {
    * @param response - Framework-specific response object
    * @returns Updated response and/or headers
    */
-  async clearSession(
-    response: TResponse,
-  ): Promise<{ response?: TResponse; headers?: HeadersBag }> {
+  async clearSession(response: TResponse): Promise<{ response?: TResponse; headers?: HeadersBag }> {
     return this.storage.clearSession(response);
   }
 
@@ -188,18 +185,14 @@ export class AuthService<TRequest, TResponse> {
   /**
    * Convenience: Get sign-in URL.
    */
-  async getSignInUrl(
-    options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {},
-  ) {
+  async getSignInUrl(options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {}) {
     return this.operations.getSignInUrl(options);
   }
 
   /**
    * Convenience: Get sign-up URL.
    */
-  async getSignUpUrl(
-    options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {},
-  ) {
+  async getSignUpUrl(options: Omit<GetAuthorizationUrlOptions, 'screenHint'> = {}) {
     return this.operations.getSignUpUrl(options);
   }
 
@@ -220,11 +213,7 @@ export class AuthService<TRequest, TResponse> {
    * @param options - OAuth callback options (code, state)
    * @returns Updated response, return pathname, and auth response
    */
-  async handleCallback(
-    _request: TRequest,
-    response: TResponse,
-    options: { code: string; state?: string },
-  ) {
+  async handleCallback(_request: TRequest, response: TResponse, options: { code: string; state?: string }) {
     // Authenticate with WorkOS using the OAuth code
     const authResponse = await this.client.userManagement.authenticateWithCode({
       code: options.code,
@@ -240,10 +229,7 @@ export class AuthService<TRequest, TResponse> {
     };
 
     const encryptedSession = await this.core.encryptSession(session);
-    const { response: updatedResponse, headers } = await this.saveSession(
-      response,
-      encryptedSession,
-    );
+    const { response: updatedResponse, headers } = await this.saveSession(response, encryptedSession);
 
     // Parse state: format is `{internal}.{userState}` or legacy `{base64JSON}`
     let returnPathname = '/';
@@ -255,9 +241,7 @@ export class AuthService<TRequest, TResponse> {
         customState = rest.join('.'); // Rejoin in case userState contains dots
         try {
           // Reverse URL-safe base64 encoding and decode
-          const decoded = (internal ?? '')
-            .replace(/-/g, '+')
-            .replace(/_/g, '/');
+          const decoded = (internal ?? '').replace(/-/g, '+').replace(/_/g, '/');
           const parsed = JSON.parse(atob(decoded));
           returnPathname = parsed.returnPathname || '/';
         } catch {

--- a/src/service/factory.ts
+++ b/src/service/factory.ts
@@ -4,10 +4,7 @@ import { getFullConfig } from '../core/config.js';
 import type { AuthKitConfig } from '../core/config/types.js';
 import { getWorkOS } from '../core/client/workos.js';
 import sessionEncryption from '../core/encryption/ironWebcryptoEncryption.js';
-import type {
-  SessionEncryption,
-  SessionStorage,
-} from '../core/session/types.js';
+import type { SessionEncryption, SessionStorage } from '../core/session/types.js';
 import { AuthService } from './AuthService.js';
 
 /**
@@ -38,9 +35,7 @@ import { AuthService } from './AuthService.js';
  * ```
  */
 export function createAuthService<TRequest, TResponse>(options: {
-  sessionStorageFactory: (
-    config: AuthKitConfig,
-  ) => SessionStorage<TRequest, TResponse>;
+  sessionStorageFactory: (config: AuthKitConfig) => SessionStorage<TRequest, TResponse>;
   clientFactory?: (config: AuthKitConfig) => WorkOS;
   encryptionFactory?: (config: AuthKitConfig) => SessionEncryption;
 }): AuthService<TRequest, TResponse> {
@@ -62,21 +57,17 @@ export function createAuthService<TRequest, TResponse>(options: {
   // Return proxy that lazily delegates to the real service
   // This allows configure() to be called after createAuthService() but before first use
   return {
-    withAuth: request => getService().withAuth(request),
-    getSession: request => getService().getSession(request),
-    saveSession: (response, sessionData) =>
-      getService().saveSession(response, sessionData),
-    clearSession: response => getService().clearSession(response),
+    withAuth: (request) => getService().withAuth(request),
+    getSession: (request) => getService().getSession(request),
+    saveSession: (response, sessionData) => getService().saveSession(response, sessionData),
+    clearSession: (response) => getService().clearSession(response),
     signOut: (sessionId, opts) => getService().signOut(sessionId, opts),
-    switchOrganization: (session, organizationId) =>
-      getService().switchOrganization(session, organizationId),
-    refreshSession: (session, organizationId) =>
-      getService().refreshSession(session, organizationId),
-    getAuthorizationUrl: opts => getService().getAuthorizationUrl(opts),
-    getSignInUrl: opts => getService().getSignInUrl(opts),
-    getSignUpUrl: opts => getService().getSignUpUrl(opts),
+    switchOrganization: (session, organizationId) => getService().switchOrganization(session, organizationId),
+    refreshSession: (session, organizationId) => getService().refreshSession(session, organizationId),
+    getAuthorizationUrl: (opts) => getService().getAuthorizationUrl(opts),
+    getSignInUrl: (opts) => getService().getSignInUrl(opts),
+    getSignUpUrl: (opts) => getService().getSignUpUrl(opts),
     getWorkOS: () => getService().getWorkOS(),
-    handleCallback: (request, response, opts) =>
-      getService().handleCallback(request, response, opts),
+    handleCallback: (request, response, opts) => getService().handleCallback(request, response, opts),
   } as AuthService<TRequest, TResponse>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,7 @@
  * @param fn - The function to be called once.
  * @returns A function that can only be called once.
  */
-export function once<TArgs extends unknown[], TReturn>(
-  fn: (...args: TArgs) => TReturn,
-): (...args: TArgs) => TReturn {
+export function once<TArgs extends unknown[], TReturn>(fn: (...args: TArgs) => TReturn): (...args: TArgs) => TReturn {
   let called = false;
   let result: TReturn;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,14 +8,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
-      exclude: [
-        'node_modules/',
-        'dist/',
-        'coverage/',
-        '**/*.spec.ts',
-        '**/*.test.ts',
-        'vitest.config.ts',
-      ],
+      exclude: ['node_modules/', 'dist/', 'coverage/', '**/*.spec.ts', '**/*.test.ts', 'vitest.config.ts'],
       include: ['src/**/*.ts'],
       thresholds: {
         global: {


### PR DESCRIPTION
## Summary

Migrates code formatting from Prettier to oxfmt for consistency with the rest of the WorkOS OSS repos (authkit-nextjs, cli, authkit-tanstack-start, skills) that have already adopted oxfmt. Removes prettier.config.js and .prettierignore, adds .oxfmtrc.json with matching settings (singleQuote, semi, trailingComma=all, printWidth=120), updates package.json scripts and CI workflow, and reformats all source and test files.

## What was tested

### Automated

- 135/135 tests passing across 11 test files
- TypeScript typecheck passes (`tsc --noEmit`)
- Build passes (`tsc`)
- `format:check` passes on all 43 files

### Manual

Library verification (no web UI). A 7-part scenario script was run covering:

1. oxfmt binary available (v0.42.0) ✅
2. `format:check` passes on all 43 files ✅
3. `.oxfmtrc.json` exists with correct settings ✅
4. Prettier config files removed ✅
5. prettier removed from devDependencies, oxfmt added ✅
6. package.json scripts reference oxfmt, not prettier ✅
7. CI workflow references format:check, no prettier references ✅

**Edge case**: Verified format idempotency — running `oxfmt .` produces zero source file changes, confirming all files were properly reformatted.

## Verification

This is a tooling/formatting migration with no behavioral changes. All 135 existing tests pass, confirming no regressions. The formatting is idempotent — re-running oxfmt produces no changes.

## Changes

- **Removed**: `prettier.config.js`, `.prettierignore`, `prettier` devDependency
- **Added**: `.oxfmtrc.json`, `oxfmt` devDependency (v0.42.0)
- **Updated**: `package.json` scripts (`format`, `format:check` now use oxfmt)
- **Updated**: `.github/workflows/ci.yml` to reference `format:check`
- **Reformatted**: 24 source and test files (whitespace/line-wrapping only)

30 files changed, 342 insertions, 380 deletions.

## Follow-ups

None — this is a straightforward tooling migration matching the pattern established in sibling repos.