### PR TITLE
fix: sanitize returnPathname decoded from OAuth state (CWE-601)

### DIFF
--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -11,6 +11,7 @@ import type {
   SessionEncryption,
   SessionStorage,
 } from '../core/session/types.js';
+import { sanitizeReturnPathname } from '../utils.js';
 
 /**
  * Framework-agnostic authentication service.
@@ -245,8 +246,12 @@ export class AuthService<TRequest, TResponse> {
       encryptedSession,
     );
 
-    // Parse state: format is `{internal}.{userState}` or legacy `{base64JSON}`
-    let returnPathname = '/';
+    // Parse state: format is `{internal}.{userState}` or legacy `{base64JSON}`.
+    // The returnPathname encoded in state is attacker-influenceable, so we
+    // always pass it through sanitizeReturnPathname before returning — this
+    // guarantees downstream consumers get a safe, origin-relative path and
+    // can't accidentally build an open-redirect (CWE-601).
+    let rawReturnPathname: unknown;
     let customState: string | undefined;
 
     if (options.state) {
@@ -259,7 +264,7 @@ export class AuthService<TRequest, TResponse> {
             .replace(/-/g, '+')
             .replace(/_/g, '/');
           const parsed = JSON.parse(atob(decoded));
-          returnPathname = parsed.returnPathname || '/';
+          rawReturnPathname = parsed.returnPathname;
         } catch {
           // Malformed internal state, use default
         }
@@ -267,7 +272,7 @@ export class AuthService<TRequest, TResponse> {
         try {
           const parsed = JSON.parse(atob(options.state));
           if (parsed.returnPathname) {
-            returnPathname = parsed.returnPathname;
+            rawReturnPathname = parsed.returnPathname;
           } else {
             customState = options.state;
           }
@@ -280,7 +285,7 @@ export class AuthService<TRequest, TResponse> {
     return {
       response: updatedResponse,
       headers,
-      returnPathname,
+      returnPathname: sanitizeReturnPathname(rawReturnPathname),
       state: customState,
       authResponse,
     };

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { once } from './utils.js';
+import { once, sanitizeReturnPathname } from './utils.js';
 
 describe('utils', () => {
   describe('once', () => {
@@ -7,6 +7,102 @@ describe('utils', () => {
       const fn = once(() => ++num);
       expect(fn()).toEqual(1);
       expect(fn()).toEqual(1); // test it's the same on every call
+    });
+  });
+
+  describe('sanitizeReturnPathname (CWE-601 open-redirect protection)', () => {
+    describe('neutralizes hostile input to same-origin relative paths', () => {
+      // Each payload is something an attacker could smuggle via OAuth state.
+      // The result must always start with exactly one `/`, so when a caller
+      // emits it as a `Location` header the browser resolves against the
+      // current (trusted) origin — never off-origin.
+      it.each([
+        ['absolute URL to evil host', 'https://evil.com/steal'],
+        ['absolute http URL', 'http://evil.com/steal'],
+        ['protocol-relative URL', '//evil.com/steal'],
+        ['backslash smuggle', '/\\evil.com/path'],
+        ['double-backslash', '\\\\evil.com/path'],
+        ['javascript: scheme', 'javascript:alert(1)'],
+        ['data: scheme', 'data:text/html,<script>alert(1)</script>'],
+        ['tab smuggling', '/\tevil.com'],
+        ['newline smuggling', '/\nevil.com'],
+        ['carriage-return smuggling', '/\revil.com'],
+      ])('%s stays on trusted origin when resolved', (_desc, payload) => {
+        const result = sanitizeReturnPathname(payload);
+
+        // Always exactly one leading slash (not zero, not two).
+        expect(result.startsWith('/')).toBe(true);
+        expect(result.startsWith('//')).toBe(false);
+
+        // Resolving against any trusted origin keeps the host unchanged.
+        const resolved = new URL(result, 'https://trusted.example.com');
+        expect(resolved.origin).toBe('https://trusted.example.com');
+        expect(resolved.host).not.toBe('evil.com');
+      });
+    });
+
+    describe('preserves legitimate values', () => {
+      it('keeps a simple path', () => {
+        expect(sanitizeReturnPathname('/dashboard')).toBe('/dashboard');
+      });
+
+      it('keeps pathname + query', () => {
+        expect(sanitizeReturnPathname('/dashboard?tab=settings')).toBe(
+          '/dashboard?tab=settings',
+        );
+      });
+
+      it('keeps hash fragments for client-side routing / anchors', () => {
+        expect(sanitizeReturnPathname('/dashboard#billing')).toBe(
+          '/dashboard#billing',
+        );
+      });
+
+      it('keeps path + query + hash together', () => {
+        expect(
+          sanitizeReturnPathname('/docs/api?v=2#auth'),
+        ).toBe('/docs/api?v=2#auth');
+      });
+    });
+
+    describe('fallback behavior for missing input', () => {
+      it('returns default fallback for undefined', () => {
+        expect(sanitizeReturnPathname(undefined)).toBe('/');
+      });
+
+      it('returns default fallback for null', () => {
+        expect(sanitizeReturnPathname(null)).toBe('/');
+      });
+
+      it('returns default fallback for empty string', () => {
+        expect(sanitizeReturnPathname('')).toBe('/');
+      });
+
+      it('returns default fallback for non-string types', () => {
+        expect(sanitizeReturnPathname(42)).toBe('/');
+        expect(sanitizeReturnPathname({})).toBe('/');
+      });
+
+      it('accepts a custom fallback', () => {
+        expect(sanitizeReturnPathname(undefined, '/login')).toBe('/login');
+      });
+
+      it('sanitizes an unsafe custom fallback (fallback is not trusted)', () => {
+        // A caller that accidentally passes a hostile fallback must not get
+        // an off-origin redirect target back. The fallback goes through the
+        // same parser as the primary input.
+        expect(sanitizeReturnPathname(undefined, '//evil.com')).toBe('/');
+        expect(sanitizeReturnPathname(undefined, 'https://evil.com/x')).toBe(
+          '/x',
+        );
+      });
+
+      it('backstops to `/` when both input and fallback are unusable', () => {
+        expect(sanitizeReturnPathname(undefined, '')).toBe('/');
+        expect(sanitizeReturnPathname(null, null as unknown as string)).toBe(
+          '/',
+        );
+      });
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,46 @@ export function once<TArgs extends unknown[], TReturn>(
     return result;
   };
 }
+
+/**
+ * Normalize a post-auth return path to a safe, same-origin relative URL.
+ *
+ * `returnPathname` travels through the OAuth `state` parameter, which is
+ * attacker-influenceable. Without normalization, a crafted value such as
+ * `https://evil.com`, `//evil.com`, or `/\evil.com` can cause downstream
+ * callers to emit an off-origin `Location` header and redirect the user
+ * after a successful sign-in — an open-redirect / phishing primitive
+ * (CWE-601).
+ *
+ * Strategy: parse the untrusted value against a throwaway origin so the
+ * WHATWG URL parser strips any smuggled host, scheme, backslash, tab, or
+ * newline; then rebuild as `pathname + search + hash` with a leading-slash
+ * normalization that defuses the `//evil.com` protocol-relative case.
+ *
+ * The returned value is always a string beginning with exactly one `/`.
+ *
+ * @param input - Untrusted return-path candidate (typically decoded from OAuth state)
+ * @param fallback - Value to return for empty/invalid input (default `'/'`)
+ * @returns A safe, origin-relative path
+ */
+export function sanitizeReturnPathname(
+  input: unknown,
+  fallback: string = '/',
+): string {
+  // The fallback is also an input to this helper — a caller who passes
+  // `'//evil.com'` as their fallback must not get an off-origin redirect
+  // back, so it goes through the same safety transform as `input`. If both
+  // are unsafe or unparseable we end up at `'/'`, which is trivially safe.
+  const toSafePath = (value: unknown): string | null => {
+    if (typeof value !== 'string' || value.length === 0) return null;
+    try {
+      const parsed = new URL(value, 'https://placeholder.invalid');
+      const path = '/' + parsed.pathname.replace(/^\/+/, '');
+      return `${path}${parsed.search}${parsed.hash}`;
+    } catch {
+      return null;
+    }
+  };
+
+  return toSafePath(input) ?? toSafePath(fallback) ?? '/';
+}


### PR DESCRIPTION
## Summary

- `handleCallback` decoded `returnPathname` from the OAuth `state` parameter and returned it to callers verbatim. Because `state` round-trips through the IdP and is attacker-influenceable, a crafted value (`https://evil.com`, `//evil.com`, `/\evil.com`, `javascript:…`) could flow into a downstream SDK's `Location` header and redirect the user off-origin after a successful sign-in — a credential-phishing primitive (CWE-601).
- Centralizes the fix at the library layer so every SDK inherits a safe value. A new `sanitizeReturnPathname` utility parses the untrusted value against a throwaway origin (the WHATWG URL parser strips any smuggled host, scheme, backslash, tab, or newline) and rebuilds a same-origin relative path as `pathname + search + hash` with a leading-slash normalization that defuses the `//evil.com` protocol-relative case.
- The `fallback` parameter goes through the same transform so a caller's custom fallback can't reopen the hole.

## Contract change

The returned `returnPathname` is now **always** a string beginning with exactly one `/`, safe to emit directly as a relative `Location` header. Downstream SDKs that previously blindly echoed this value (e.g. authkit-sveltekit, see https://github.com/workos/authkit-sveltekit/pull/15) are automatically patched after a version bump. Downstream SDKs that already sanitized (authkit-nextjs, authkit-tanstack-start) are unaffected.

## Motivation

- **authkit-sveltekit** was actively vulnerable to this via its callback handler (fixed at the SDK layer in workos/authkit-sveltekit#15).
- **authkit-tanstack-start** is not vulnerable to open-redirect (its `buildRedirectUrl` happens to anchor to the trusted origin) but its redirect target still passes through this value, so it benefits from the tighter contract.
- **authkit-nextjs** already reconstructs at the SDK layer, but no reason for every SDK author to re-derive the same mitigation.

Fixing once here removes an entire class of bug from every current and future consumer.