### PR TITLE
v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos/authkit-session",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Framework-agnostic authentication library for WorkOS with pluggable storage adapters",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
Patch release bumping `@workos/authkit-session` from `0.5.0` to `0.5.1`.

## What's in this release

- **Security (CWE-601):** `handleCallback` now sanitizes `returnPathname` decoded from OAuth `state` before returning it. A crafted `state` value (e.g. `https://evil.com`, `//evil.com`, `/\evil.com`) could previously flow into a downstream SDK's `Location` header and become an open-redirect primitive. The new `sanitizeReturnPathname` utility parses against a throwaway origin and rebuilds a same-origin relative path beginning with exactly one `/`. The `fallback` parameter goes through the same pipeline so a hostile fallback can't reopen the hole. (merged in f56e1d6)

## Post-merge checklist

- [ ] Tag `v0.5.1` and cut a GitHub release
- [ ] Confirm the `release: published` workflow publishes to npm with provenance