### PR TITLE
test: integration coverage for hostile returnPathname sanitization (CWE-601)

### DIFF
--- a/src/service/AuthService.spec.ts
+++ b/src/service/AuthService.spec.ts
@@ -642,6 +642,39 @@ describe('AuthService', () => {
       expect(result.returnPathname).toBe('/');
     });
 
+    it.each([
+      ['absolute URL', 'https://evil.com/steal'],
+      ['protocol-relative', '//evil.com/steal'],
+      ['backslash smuggle', '/\\evil.com'],
+      ['javascript: scheme', 'javascript:alert(1)'],
+    ])(
+      'sanitizes a hostile returnPathname end-to-end: %s',
+      async (_label, hostilePathname) => {
+        const realStorage = makeStorage();
+        const realService = new AuthService(
+          mockConfig as any,
+          realStorage as any,
+          makeClient() as any,
+          sessionEncryption,
+        );
+
+        const { cookieName } = await realService.createAuthorization('res', {
+          returnPathname: hostilePathname,
+          state: 'custom-state',
+        });
+        const sealedState = realStorage.cookies.get(cookieName)!;
+
+        const result = await realService.handleCallback('req', 'res', {
+          code: 'code',
+          state: sealedState,
+        });
+
+        expect(result.returnPathname.startsWith('/')).toBe(true);
+        const trusted = 'https://trusted.example.com';
+        expect(new URL(result.returnPathname, trusted).origin).toBe(trusted);
+      },
+    );
+
     it('best-effort clears the verifier cookie on OAuthStateMismatchError', async () => {
       const realStorage = makeStorage();
       const realService = new AuthService(


### PR DESCRIPTION
## Summary

Closes the integration-level gap identified while reviewing v0.5.1 confidence. The existing coverage for the CWE-601 fix is split across two layers:

- **Unit (`src/utils.spec.ts`):** 21 cases prove `sanitizeReturnPathname` correctly neutralizes hostile input in isolation. ✓
- **Integration (`src/service/AuthService.spec.ts`):** exercises `handleCallback` but only with legitimate paths (`/dashboard`, `/foo`). No test feeds a hostile `returnPathname` through the full `createAuthorization → handleCallback` round-trip.

This means a future refactor that accidentally removed the `sanitizeReturnPathname(...)` call at `AuthService.ts:387` would still pass all prior tests while reintroducing the open-redirect vulnerability. This PR adds a test that would catch that.

## Changes

- 4 new `it.each` cases under `handleCallback()` — one per CWE-601 payload class: absolute URL, protocol-relative, backslash smuggle, `javascript:` scheme.
- Asserts the returned `returnPathname` starts with `/` **and** resolves to the trusted origin (the same invariant the unit tests use).

## Test plan

- [x] `pnpm test src/service/AuthService.spec.ts` — 40 tests pass (was 36)
- [x] `pnpm test` — 247 tests pass (was 243), no regressions