### PR TITLE
fix: move @workos-inc/node to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@workos-inc/node": "^8.0.0",
     "iron-webcrypto": "^2.0.0",
     "jose": "^6.1.3",
     "valibot": "^1.3.1"
   },
+  "peerDependencies": {
+    "@workos-inc/node": "^8.0.0 || ^9.0.0"
+  },
   "devDependencies": {
+    "@workos-inc/node": "^9.2.0",
     "@types/node": "^20.17.0",
     "@vitest/coverage-v8": "^4.0.17",
     "oxfmt": "^0.42.0",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,17 @@
     "jose": "^6.1.3",
     "valibot": "^1.3.1"
   },
-  "peerDependencies": {
-    "@workos-inc/node": "^8.0.0 || ^9.0.0"
-  },
   "devDependencies": {
-    "@workos-inc/node": "^9.2.0",
     "@types/node": "^20.17.0",
     "@vitest/coverage-v8": "^4.0.17",
+    "@workos-inc/node": "^9.2.0",
     "oxfmt": "^0.42.0",
     "oxlint": "^1.57.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.17"
+  },
+  "peerDependencies": {
+    "@workos-inc/node": "^8.0.0 || ^9.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@workos-inc/node':
-        specifier: ^8.0.0
-        version: 8.13.0
       iron-webcrypto:
         specifier: ^2.0.0
         version: 2.0.0
@@ -27,6 +24,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.17
         version: 4.1.4(vitest@4.1.4)
+      '@workos-inc/node':
+        specifier: ^9.2.0
+        version: 9.2.0
       oxfmt:
         specifier: ^0.42.0
         version: 0.42.0
@@ -467,9 +467,9 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
-  '@workos-inc/node@8.13.0':
-    resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
-    engines: {node: '>=20.15.0'}
+  '@workos-inc/node@9.2.0':
+    resolution: {integrity: sha512-JAEjrwgr8aETOS7YzHmSlPj+1LCXonAKGX1/B89hIZ+l+YgQGJrdFZnBqBSlDnqUaOtxDZkGwg7V3LFNkF+evg==}
+    engines: {node: '>=22.11.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1110,7 +1110,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@workos-inc/node@8.13.0':
+  '@workos-inc/node@9.2.0':
     dependencies:
       eventemitter3: 5.0.4
 


### PR DESCRIPTION
## Summary

- Moves `@workos-inc/node` from `dependencies` to `peerDependencies` with range `^8.0.0 || ^9.0.0`
- Adds `@workos-inc/node@^9.2.0` to `devDependencies` for development/testing

## Context

Users on `@workos-inc/node@9.x` are forced to use package manager `resolutions` to avoid version conflicts.

The SDK was a regular dependency pinned to `^8.0.0`, causing npm to install a **separate nested copy** alongside the consumer's v9. Since authkit-session re-exports types from the SDK (`User`, `Impersonator`, `WorkOS`, etc.), this results in type mismatches across the package boundary.

As a peer dependency, the consumer controls the SDK version and only one copy exists at runtime.

## What's NOT affected

`authkit-session` only uses `userManagement` methods (`getJwksUrl`, `getAuthorizationUrl`, `getLogoutUrl`, `authenticateWithRefreshToken`, `authenticateWithCode`) — none of which changed in v9. Build and tests pass against v9.2.0.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` — 243/243 tests pass
- [x] `authkit-tanstack-start` build + 217 tests pass with linked authkit-session
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-session/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->