### PR TITLE
fix: deduplicate concurrent server-side token refresh calls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,9 +27,8 @@ If applicable, add screenshots to help explain your problem.
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]
-- Framework adapter (authkit-nextjs / authkit-tanstack-start) and version
-- Framework version (Next.js / TanStack Start / etc.)
-- Next.js version [e.g. 14.2.5]
+- Framework adapter and version [e.g. authkit-nextjs 1.0.0]
+- Framework and version [e.g. Next.js 14.2.5, TanStack Start 1.0.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,8 @@ If applicable, add screenshots to help explain your problem.
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]
-- authkit-tanstack-start version [e.g. 0.12.0]
+- Framework adapter (authkit-nextjs / authkit-tanstack-start) and version
+- Framework version (Next.js / TanStack Start / etc.)
 - Next.js version [e.g. 14.2.5]
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ If applicable, add screenshots to help explain your problem.
 
 - OS: [e.g. iOS]
 - Browser [e.g. chrome, safari]
-- authkit-nextjs version [e.g. 0.12.0]
+- authkit-tanstack-start version [e.g. 0.12.0]
 - Next.js version [e.g. 14.2.5]
 
 **Additional context**

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -56,15 +56,15 @@ function makeExpiredSession() {
   };
 }
 
-function makeCountingClient(opts?: { delayMs?: number; fail?: () => boolean }) {
+function makeCountingClient(opts?: { fail?: () => boolean }) {
   let callCount = 0;
-  const { delayMs = 50, fail } = opts ?? {};
+  const { fail } = opts ?? {};
   const client = {
     userManagement: {
       getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
       authenticateWithRefreshToken: async () => {
         callCount++;
-        await new Promise(r => setTimeout(r, delayMs));
+        await new Promise(r => setTimeout(r, 50));
         if (fail?.()) throw new Error('Refresh failed');
         return {
           accessToken: newJwt,
@@ -294,6 +294,7 @@ describe('AuthKitCore', () => {
     });
 
     it('deduplicates concurrent calls with the same refresh token', async () => {
+      vi.useFakeTimers();
       const { client, getCallCount } = makeCountingClient();
       const testCore = new AuthKitCore(
         mockConfig as any,
@@ -302,20 +303,25 @@ describe('AuthKitCore', () => {
       );
 
       const session = makeExpiredSession();
-      const results = await Promise.all([
+      const pending = Promise.all([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const results = await pending;
 
       expect(getCallCount()).toBe(1);
       for (const r of results) {
         expect(r.refreshed).toBe(true);
         expect(r.session.accessToken).toBe(newJwt);
       }
+      vi.useRealTimers();
     });
 
     it('propagates errors to all concurrent waiters', async () => {
+      vi.useFakeTimers();
       const { client, getCallCount } = makeCountingClient({
         fail: () => true,
       });
@@ -326,11 +332,14 @@ describe('AuthKitCore', () => {
       );
 
       const session = makeExpiredSession();
-      const results = await Promise.allSettled([
+      const pending = Promise.allSettled([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const results = await pending;
 
       expect(getCallCount()).toBe(1);
       for (const r of results) {
@@ -339,12 +348,13 @@ describe('AuthKitCore', () => {
           expect(r.reason).toBeInstanceOf(TokenRefreshError);
         }
       }
+      vi.useRealTimers();
     });
 
     it('retries after a failed concurrent batch', async () => {
+      vi.useFakeTimers();
       let shouldFail = true;
       const { client, getCallCount } = makeCountingClient({
-        delayMs: 20,
         fail: () => shouldFail,
       });
       const testCore = new AuthKitCore(
@@ -355,20 +365,26 @@ describe('AuthKitCore', () => {
 
       const session = makeExpiredSession();
 
-      await Promise.allSettled([
+      const firstBatch = Promise.allSettled([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
+      await vi.advanceTimersByTimeAsync(50);
+      await firstBatch;
       expect(getCallCount()).toBe(1);
 
       shouldFail = false;
-      const result = await testCore.validateAndRefresh(session);
+      const retryPending = testCore.validateAndRefresh(session);
+      await vi.advanceTimersByTimeAsync(50);
+      const result = await retryPending;
       expect(getCallCount()).toBe(2);
       expect(result.refreshed).toBe(true);
       expect(result.session.accessToken).toBe(newJwt);
+      vi.useRealTimers();
     });
 
     it('deduplicates separately per organizationId', async () => {
+      vi.useFakeTimers();
       const { client, getCallCount } = makeCountingClient();
       const testCore = new AuthKitCore(
         mockConfig as any,
@@ -377,12 +393,16 @@ describe('AuthKitCore', () => {
       );
 
       const session = makeExpiredSession();
-      await Promise.all([
+      const pending = Promise.all([
         testCore.validateAndRefresh(session, { organizationId: 'org_a' }),
         testCore.validateAndRefresh(session, { organizationId: 'org_b' }),
       ]);
 
+      await vi.advanceTimersByTimeAsync(50);
+      await pending;
+
       expect(getCallCount()).toBe(2);
+      vi.useRealTimers();
     });
   });
 

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -44,6 +44,43 @@ const mockEncryption = {
   }),
 };
 
+const newJwt =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
+
+function makeExpiredSession() {
+  return {
+    accessToken: 'expired-jwt',
+    refreshToken: 'rt-1',
+    user: mockUser,
+    impersonator: undefined,
+  };
+}
+
+function makeCountingClient(opts?: {
+  delayMs?: number;
+  fail?: () => boolean;
+}) {
+  let callCount = 0;
+  const { delayMs = 50, fail } = opts ?? {};
+  const client = {
+    userManagement: {
+      getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+      authenticateWithRefreshToken: async () => {
+        callCount++;
+        await new Promise((r) => setTimeout(r, delayMs));
+        if (fail?.()) throw new Error('Refresh failed');
+        return {
+          accessToken: newJwt,
+          refreshToken: 'new-rt',
+          user: mockUser,
+          impersonator: undefined,
+        };
+      },
+    },
+  };
+  return { client, getCallCount: () => callCount };
+}
+
 describe('AuthKitCore', () => {
   let core: AuthKitCore;
 
@@ -260,44 +297,21 @@ describe('AuthKitCore', () => {
     });
 
     it('deduplicates concurrent calls with the same refresh token', async () => {
-      const newJwt =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
-      let callCount = 0;
-      const delayedClient = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            await new Promise((r) => setTimeout(r, 50));
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = makeCountingClient();
       const testCore = new AuthKitCore(
         mockConfig as any,
-        delayedClient as any,
+        client as any,
         mockEncryption as any,
       );
 
-      const session = {
-        accessToken: 'expired-jwt',
-        refreshToken: 'rt-1',
-        user: mockUser,
-        impersonator: undefined,
-      };
-
+      const session = makeExpiredSession();
       const results = await Promise.all([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
 
-      expect(callCount).toBe(1);
+      expect(getCallCount()).toBe(1);
       for (const r of results) {
         expect(r.refreshed).toBe(true);
         expect(r.session.accessToken).toBe(newJwt);
@@ -305,37 +319,23 @@ describe('AuthKitCore', () => {
     });
 
     it('propagates errors to all concurrent waiters', async () => {
-      let callCount = 0;
-      const failingClient = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            await new Promise((r) => setTimeout(r, 50));
-            throw new Error('Rate limit exceeded');
-          },
-        },
-      };
+      const { client, getCallCount } = makeCountingClient({
+        fail: () => true,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
-        failingClient as any,
+        client as any,
         mockEncryption as any,
       );
 
-      const session = {
-        accessToken: 'expired-jwt',
-        refreshToken: 'rt-1',
-        user: mockUser,
-        impersonator: undefined,
-      };
-
+      const session = makeExpiredSession();
       const results = await Promise.allSettled([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
 
-      expect(callCount).toBe(1);
+      expect(getCallCount()).toBe(1);
       for (const r of results) {
         expect(r.status).toBe('rejected');
         if (r.status === 'rejected') {
@@ -345,101 +345,53 @@ describe('AuthKitCore', () => {
     });
 
     it('retries after a failed concurrent batch', async () => {
-      const newJwt =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
-      let callCount = 0;
       let shouldFail = true;
-      const retryClient = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            await new Promise((r) => setTimeout(r, 20));
-            if (shouldFail) throw new Error('Temporary failure');
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = makeCountingClient({
+        delayMs: 20,
+        fail: () => shouldFail,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
-        retryClient as any,
+        client as any,
         mockEncryption as any,
       );
 
-      const session = {
-        accessToken: 'expired-jwt',
-        refreshToken: 'rt-1',
-        user: mockUser,
-        impersonator: undefined,
-      };
+      const session = makeExpiredSession();
 
-      // First batch: all fail, but only 1 API call
       await Promise.allSettled([
         testCore.validateAndRefresh(session),
         testCore.validateAndRefresh(session),
       ]);
-      expect(callCount).toBe(1);
+      expect(getCallCount()).toBe(1);
 
-      // Second call: should retry fresh (map was cleared in finally)
       shouldFail = false;
       const result = await testCore.validateAndRefresh(session);
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(result.refreshed).toBe(true);
       expect(result.session.accessToken).toBe(newJwt);
     });
 
     it('deduplicates separately per organizationId', async () => {
-      const newJwt =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
-      let callCount = 0;
-      const orgClient = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            await new Promise((r) => setTimeout(r, 50));
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = makeCountingClient();
       const testCore = new AuthKitCore(
         mockConfig as any,
-        orgClient as any,
+        client as any,
         mockEncryption as any,
       );
 
-      const session = {
-        accessToken: 'expired-jwt',
-        refreshToken: 'rt-1',
-        user: mockUser,
-        impersonator: undefined,
-      };
-
+      const session = makeExpiredSession();
       await Promise.all([
         testCore.validateAndRefresh(session, { organizationId: 'org_a' }),
         testCore.validateAndRefresh(session, { organizationId: 'org_b' }),
       ]);
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
     });
   });
 
   describe('validateAndRefresh()', () => {
-    // Decodable JWT with sid + exp + org_id. Signature is garbage → verifyToken false.
     const oldJwt =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fOTk5IiwiZXhwIjoxMDAwMDAwMDAwLCJvcmdfaWQiOiJvcmdfYWJjIn0.sig';
-    const newJwt =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
 
     function makeRefreshClient(capture?: { opts?: any }) {
       return {

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -56,10 +56,7 @@ function makeExpiredSession() {
   };
 }
 
-function makeCountingClient(opts?: {
-  delayMs?: number;
-  fail?: () => boolean;
-}) {
+function makeCountingClient(opts?: { delayMs?: number; fail?: () => boolean }) {
   let callCount = 0;
   const { delayMs = 50, fail } = opts ?? {};
   const client = {
@@ -67,7 +64,7 @@ function makeCountingClient(opts?: {
       getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
       authenticateWithRefreshToken: async () => {
         callCount++;
-        await new Promise((r) => setTimeout(r, delayMs));
+        await new Promise(r => setTimeout(r, delayMs));
         if (fail?.()) throw new Error('Refresh failed');
         return {
           accessToken: newJwt,

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -258,6 +258,180 @@ describe('AuthKitCore', () => {
         TokenRefreshError,
       );
     });
+
+    it('deduplicates concurrent calls with the same refresh token', async () => {
+      const newJwt =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
+      let callCount = 0;
+      const delayedClient = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            await new Promise((r) => setTimeout(r, 50));
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        delayedClient as any,
+        mockEncryption as any,
+      );
+
+      const session = {
+        accessToken: 'expired-jwt',
+        refreshToken: 'rt-1',
+        user: mockUser,
+        impersonator: undefined,
+      };
+
+      const results = await Promise.all([
+        testCore.validateAndRefresh(session),
+        testCore.validateAndRefresh(session),
+        testCore.validateAndRefresh(session),
+      ]);
+
+      expect(callCount).toBe(1);
+      for (const r of results) {
+        expect(r.refreshed).toBe(true);
+        expect(r.session.accessToken).toBe(newJwt);
+      }
+    });
+
+    it('propagates errors to all concurrent waiters', async () => {
+      let callCount = 0;
+      const failingClient = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            await new Promise((r) => setTimeout(r, 50));
+            throw new Error('Rate limit exceeded');
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        failingClient as any,
+        mockEncryption as any,
+      );
+
+      const session = {
+        accessToken: 'expired-jwt',
+        refreshToken: 'rt-1',
+        user: mockUser,
+        impersonator: undefined,
+      };
+
+      const results = await Promise.allSettled([
+        testCore.validateAndRefresh(session),
+        testCore.validateAndRefresh(session),
+        testCore.validateAndRefresh(session),
+      ]);
+
+      expect(callCount).toBe(1);
+      for (const r of results) {
+        expect(r.status).toBe('rejected');
+        if (r.status === 'rejected') {
+          expect(r.reason).toBeInstanceOf(TokenRefreshError);
+        }
+      }
+    });
+
+    it('retries after a failed concurrent batch', async () => {
+      const newJwt =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
+      let callCount = 0;
+      let shouldFail = true;
+      const retryClient = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            await new Promise((r) => setTimeout(r, 20));
+            if (shouldFail) throw new Error('Temporary failure');
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        retryClient as any,
+        mockEncryption as any,
+      );
+
+      const session = {
+        accessToken: 'expired-jwt',
+        refreshToken: 'rt-1',
+        user: mockUser,
+        impersonator: undefined,
+      };
+
+      // First batch: all fail, but only 1 API call
+      await Promise.allSettled([
+        testCore.validateAndRefresh(session),
+        testCore.validateAndRefresh(session),
+      ]);
+      expect(callCount).toBe(1);
+
+      // Second call: should retry fresh (map was cleared in finally)
+      shouldFail = false;
+      const result = await testCore.validateAndRefresh(session);
+      expect(callCount).toBe(2);
+      expect(result.refreshed).toBe(true);
+      expect(result.session.accessToken).toBe(newJwt);
+    });
+
+    it('deduplicates separately per organizationId', async () => {
+      const newJwt =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInNpZCI6InNlc3Npb25fbmV3IiwiZXhwIjozMDAwMDAwMDAwfQ.sig';
+      let callCount = 0;
+      const orgClient = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            await new Promise((r) => setTimeout(r, 50));
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        orgClient as any,
+        mockEncryption as any,
+      );
+
+      const session = {
+        accessToken: 'expired-jwt',
+        refreshToken: 'rt-1',
+        user: mockUser,
+        impersonator: undefined,
+      };
+
+      await Promise.all([
+        testCore.validateAndRefresh(session, { organizationId: 'org_a' }),
+        testCore.validateAndRefresh(session, { organizationId: 'org_b' }),
+      ]);
+
+      expect(callCount).toBe(2);
+    });
   });
 
   describe('validateAndRefresh()', () => {

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -224,7 +224,9 @@ export class AuthKitCore {
     const existing = this.inflightRefreshes.get(key);
     if (existing) return existing;
 
-    const cleanup = () => { this.inflightRefreshes.delete(key); };
+    const cleanup = () => {
+      this.inflightRefreshes.delete(key);
+    };
     const promise = (async () => {
       try {
         const result =

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -220,10 +220,11 @@ export class AuthKitCore {
     organizationId?: string,
     context?: { userId?: string; sessionId?: string },
   ): Promise<RefreshResult> {
-    const key = `${refreshToken}:${organizationId ?? ''}`;
+    const key = `${refreshToken}\0${organizationId ?? ''}`;
     const existing = this.inflightRefreshes.get(key);
     if (existing) return existing;
 
+    const cleanup = () => { this.inflightRefreshes.delete(key); };
     const promise = (async () => {
       try {
         const result =
@@ -241,12 +242,11 @@ export class AuthKitCore {
         };
       } catch (error) {
         throw new TokenRefreshError('Failed to refresh tokens', error, context);
-      } finally {
-        this.inflightRefreshes.delete(key);
       }
     })();
 
     this.inflightRefreshes.set(key, promise);
+    promise.then(cleanup, cleanup);
     return promise;
   }
 

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -34,6 +34,15 @@ export class AuthKitCore {
   private client: WorkOS;
   private encryption: SessionEncryption;
   private clientId: string;
+  private inflightRefreshes = new Map<
+    string,
+    Promise<{
+      accessToken: string;
+      refreshToken: string;
+      user: User;
+      impersonator: Impersonator | undefined;
+    }>
+  >();
 
   constructor(
     config: AuthKitConfig,
@@ -217,23 +226,34 @@ export class AuthKitCore {
     user: User;
     impersonator: Impersonator | undefined;
   }> {
-    try {
-      const result =
-        await this.client.userManagement.authenticateWithRefreshToken({
-          refreshToken,
-          clientId: this.clientId,
-          organizationId,
-        });
+    const key = `${refreshToken}:${organizationId ?? ''}`;
+    const existing = this.inflightRefreshes.get(key);
+    if (existing) return existing;
 
-      return {
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
-        user: result.user,
-        impersonator: result.impersonator,
-      };
-    } catch (error) {
-      throw new TokenRefreshError('Failed to refresh tokens', error, context);
-    }
+    const promise = (async () => {
+      try {
+        const result =
+          await this.client.userManagement.authenticateWithRefreshToken({
+            refreshToken,
+            clientId: this.clientId,
+            organizationId,
+          });
+
+        return {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          user: result.user,
+          impersonator: result.impersonator,
+        };
+      } catch (error) {
+        throw new TokenRefreshError('Failed to refresh tokens', error, context);
+      } finally {
+        this.inflightRefreshes.delete(key);
+      }
+    })();
+
+    this.inflightRefreshes.set(key, promise);
+    return promise;
   }
 
   /**

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -16,6 +16,13 @@ import type {
   SessionEncryption,
 } from './session/types.js';
 
+type RefreshResult = {
+  accessToken: string;
+  refreshToken: string;
+  user: User;
+  impersonator: Impersonator | undefined;
+};
+
 /**
  * AuthKitCore provides pure business logic for authentication operations.
  *
@@ -34,15 +41,7 @@ export class AuthKitCore {
   private client: WorkOS;
   private encryption: SessionEncryption;
   private clientId: string;
-  private inflightRefreshes = new Map<
-    string,
-    Promise<{
-      accessToken: string;
-      refreshToken: string;
-      user: User;
-      impersonator: Impersonator | undefined;
-    }>
-  >();
+  private inflightRefreshes = new Map<string, Promise<RefreshResult>>();
 
   constructor(
     config: AuthKitConfig,
@@ -220,12 +219,7 @@ export class AuthKitCore {
     refreshToken: string,
     organizationId?: string,
     context?: { userId?: string; sessionId?: string },
-  ): Promise<{
-    accessToken: string;
-    refreshToken: string;
-    user: User;
-    impersonator: Impersonator | undefined;
-  }> {
+  ): Promise<RefreshResult> {
     const key = `${refreshToken}:${organizationId ?? ''}`;
     const existing = this.inflightRefreshes.get(key);
     if (existing) return existing;


### PR DESCRIPTION
## Summary

- Adds an in-flight `Map` to `AuthKitCore.refreshTokens()` so concurrent calls with the same refresh token share a single WorkOS API call instead of racing
- Keyed by `${refreshToken}:${organizationId ?? ''}` — different orgs get separate API calls
- Map entry cleared in `finally` on both success and failure

## Problem

When a TanStack Start user returns after an idle period, a single page navigation fires multiple concurrent server-function loaders (e.g., 3 for `/account`). Each runs auth middleware independently, and each calls `refreshTokens()` with the same expired refresh token. Since refresh tokens are single-use, only the first call succeeds — the rest hit `RateLimitExceededException` or `TokenRefreshError`.

Customer-reported: errors from the same IP had different trace IDs, confirming separate concurrent server-fn requests (not multi-tab).

The client-side `tokenStore` already has `refreshPromise` dedup per browser tab, but there was zero server-side coordination.

## Approach

Mirrors the client-side `refreshPromise` pattern:
1. Check `inflightRefreshes` map for an existing promise with the same key
2. If found, return it (concurrent callers share the in-flight promise)
3. If not, create the promise, store it, execute, and clear in `finally`

`AuthKitCore` is instantiated once per process (via `once()` in `factory.ts`), so the map is effectively process-wide.

## Test coverage

4 new tests added to `AuthKitCore.spec.ts`:
- **Concurrent dedup**: 3 simultaneous `validateAndRefresh` calls → 1 API call, all resolve with same tokens
- **Error propagation**: API rejects → all concurrent waiters get `TokenRefreshError`
- **Retry after failure**: failed batch clears map entry, subsequent call retries fresh
- **Org-scoping**: same refresh token + different `organizationId` = 2 separate API calls

## Trade-offs

- First caller's `context` (userId/sessionId) is used for all waiters' error messages — acceptable since context is telemetry-only
- Per-process dedup only — does not coordinate across cluster workers (future consideration)

## Test plan

- [x] Reproduction test fails on `main` (3 API calls observed)
- [x] Reproduction test passes with fix (1 API call)
- [x] All 243 existing tests still pass
- [x] `pnpm build` passes (TypeScript compilation)
- [x] `authkit-tanstack-start` builds cleanly against this change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-session/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->