### PR TITLE
fix: don't format CHANGELOG.md

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,5 +7,10 @@
   "tabWidth": 2,
   "singleQuote": true,
   "printWidth": 80,
-  "ignorePatterns": ["pnpm-lock.yaml", "package-lock.json", "dist"]
+  "ignorePatterns": [
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "dist",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
This pull request makes a minor update to the `.oxfmtrc.json` configuration file by adding `CHANGELOG.md` to the list of files ignored by the formatter.