### PR TITLE
fix: drop GitHub App token from release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,17 +19,8 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ vars.SDK_BOT_APP_ID }}
-          private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}
-
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
 
   publish:
     needs: release-please

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,5 +7,10 @@
   "tabWidth": 2,
   "singleQuote": true,
   "printWidth": 80,
-  "ignorePatterns": ["pnpm-lock.yaml", "package-lock.json", "dist"]
+  "ignorePatterns": [
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "dist",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
## Summary
- Removes the `create-github-app-token` step from the release-please workflow
- release-please now uses the default `GITHUB_TOKEN` instead
- Also excludes `CHANGELOG.md` from oxfmt formatting

## Why
The GitHub App token ([failed run](https://github.com/workos/authkit-session/actions/runs/26041021430/job/76552357835)) was cargo-culted from authkit-tanstack-start where it's needed for cross-workflow triggers. With publishing inlined into the same workflow, `GITHUB_TOKEN` is sufficient — release-please gets `contents: write` + `pull-requests: write` from the workflow permissions.

No `NPM_TOKEN` needed — publishing uses npm trusted publishing via OIDC (`id-token: write` + `--provenance`).

## Test plan
- [ ] Merge → release-please workflow should run clean on main
- [ ] Next conventional commit should produce a release PR