### PR TITLE
fix: retry token refresh once on rate limit

### DIFF
--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -553,6 +553,11 @@ describe('AuthKitCore', () => {
 
       expect(error).toBeInstanceOf(TokenRefreshError);
       expect(error.message).toContain('after rate-limit retry');
+      // Cause chain: TokenRefreshError → RateLimitExceededException (retry) → RateLimitExceededException (original)
+      expect(error.cause).toBeInstanceOf(RateLimitExceededException);
+      expect((error.cause as any).cause).toBeInstanceOf(
+        RateLimitExceededException,
+      );
       vi.useRealTimers();
     });
 
@@ -669,6 +674,10 @@ describe('AuthKitCore', () => {
       expect(error.message).toContain('after rate-limit retry');
       expect(error.cause).toBeInstanceOf(Error);
       expect((error.cause as Error).message).toBe('Network failure');
+      // Original rate-limit error preserved in chain
+      expect((error.cause as Error).cause).toBeInstanceOf(
+        RateLimitExceededException,
+      );
       vi.useRealTimers();
     });
 

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -415,7 +415,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', 2);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                2,
+              );
             }
             return {
               accessToken: newJwt,
@@ -450,7 +454,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', 5);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                5,
+              );
             }
             return {
               accessToken: newJwt,
@@ -489,7 +497,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', null);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                null,
+              );
             }
             return {
               accessToken: newJwt,
@@ -521,7 +533,11 @@ describe('AuthKitCore', () => {
         userManagement: {
           getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
           authenticateWithRefreshToken: async () => {
-            throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+            throw new RateLimitExceededException(
+              'Too Many Requests',
+              'req_1',
+              1,
+            );
           },
         },
       };
@@ -549,7 +565,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', 300);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                300,
+              );
             }
             return {
               accessToken: newJwt,
@@ -585,7 +605,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', Infinity as any);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                Infinity as any,
+              );
             }
             return {
               accessToken: newJwt,
@@ -620,7 +644,11 @@ describe('AuthKitCore', () => {
           authenticateWithRefreshToken: async () => {
             callCount++;
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                1,
+              );
             }
             throw new Error('Network failure');
           },
@@ -654,7 +682,11 @@ describe('AuthKitCore', () => {
             callCount++;
             await new Promise(r => setTimeout(r, 50));
             if (callCount === 1) {
-              throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+              throw new RateLimitExceededException(
+                'Too Many Requests',
+                'req_1',
+                1,
+              );
             }
             return {
               accessToken: newJwt,

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -79,6 +79,45 @@ function makeCountingClient(opts?: { fail?: () => boolean }) {
   return { client, getCallCount: () => callCount };
 }
 
+/**
+ * Builds a userManagement client whose first refresh attempt throws a
+ * RateLimitExceededException. By default the retry succeeds; `onRetry` can make
+ * the retry throw another rate-limit error or an arbitrary error instead.
+ */
+function createRateLimitClient(opts?: {
+  retryAfter?: number | null;
+  delayMs?: number;
+  onRetry?: 'succeed' | 'rateLimit' | Error;
+}) {
+  const { retryAfter = 1, delayMs = 0, onRetry = 'succeed' } = opts ?? {};
+  let callCount = 0;
+  const rateLimit = () =>
+    new RateLimitExceededException(
+      'Too Many Requests',
+      'req_1',
+      retryAfter as any,
+    );
+  const client = {
+    userManagement: {
+      getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+      authenticateWithRefreshToken: async () => {
+        callCount++;
+        if (delayMs) await new Promise(r => setTimeout(r, delayMs));
+        if (callCount === 1) throw rateLimit();
+        if (onRetry === 'rateLimit') throw rateLimit();
+        if (onRetry instanceof Error) throw onRetry;
+        return {
+          accessToken: newJwt,
+          refreshToken: 'new-rt',
+          user: mockUser,
+          impersonator: undefined,
+        };
+      },
+    },
+  };
+  return { client, getCallCount: () => callCount };
+}
+
 describe('AuthKitCore', () => {
   let core: AuthKitCore;
 
@@ -408,28 +447,7 @@ describe('AuthKitCore', () => {
 
     it('retries once after a RateLimitExceededException', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                2,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({ retryAfter: 2 });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -440,35 +458,14 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(2000);
       const result = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(result.accessToken).toBe(newJwt);
       vi.useRealTimers();
     });
 
     it('honors retryAfter from the exception', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                5,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({ retryAfter: 5 });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -478,40 +475,21 @@ describe('AuthKitCore', () => {
       const pending = testCore.refreshTokens('rt-1');
       // Advance less than the retryAfter — should not have retried yet
       await vi.advanceTimersByTimeAsync(3000);
-      expect(callCount).toBe(1);
+      expect(getCallCount()).toBe(1);
       // Advance past retryAfter
       await vi.advanceTimersByTimeAsync(2000);
       const result = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(result.accessToken).toBe(newJwt);
       vi.useRealTimers();
     });
 
     it('defaults to 1s delay when retryAfter is null', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                null,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: null,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -522,25 +500,17 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(1000);
       const result = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(result.accessToken).toBe(newJwt);
       vi.useRealTimers();
     });
 
     it('throws TokenRefreshError when retry also hits rate limit', async () => {
       vi.useFakeTimers();
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            throw new RateLimitExceededException(
-              'Too Many Requests',
-              'req_1',
-              1,
-            );
-          },
-        },
-      };
+      const { client } = createRateLimitClient({
+        retryAfter: 1,
+        onRetry: 'rateLimit',
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -563,28 +533,9 @@ describe('AuthKitCore', () => {
 
     it('caps retryAfter at 10s', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                300,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: 300,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -596,35 +547,40 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(10_000);
       const result = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('clamps sub-1s retryAfter up to a 1s floor', async () => {
+      vi.useFakeTimers();
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: 0.3,
+      });
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      // 0.3s would be enough without a floor — the retry must NOT have fired yet
+      await vi.advanceTimersByTimeAsync(300);
+      expect(getCallCount()).toBe(1);
+      // Past the 1s floor — retry fires
+      await vi.advanceTimersByTimeAsync(700);
+      const result = await pending;
+
+      expect(getCallCount()).toBe(2);
       expect(result.accessToken).toBe(newJwt);
       vi.useRealTimers();
     });
 
     it('defaults to 1s for non-finite retryAfter values', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                Infinity as any,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: Infinity,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -635,30 +591,17 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(1000);
       const result = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(result.accessToken).toBe(newJwt);
       vi.useRealTimers();
     });
 
     it('wraps non-rate-limit retry errors correctly', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                1,
-              );
-            }
-            throw new Error('Network failure');
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: 1,
+        onRetry: new Error('Network failure'),
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -669,7 +612,7 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(1000);
       const error = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       expect(error).toBeInstanceOf(TokenRefreshError);
       expect(error.message).toContain('after rate-limit retry');
       expect(error.cause).toBeInstanceOf(Error);
@@ -683,29 +626,10 @@ describe('AuthKitCore', () => {
 
     it('shares retry result with concurrent dedup waiters', async () => {
       vi.useFakeTimers();
-      let callCount = 0;
-      const client = {
-        userManagement: {
-          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
-          authenticateWithRefreshToken: async () => {
-            callCount++;
-            await new Promise(r => setTimeout(r, 50));
-            if (callCount === 1) {
-              throw new RateLimitExceededException(
-                'Too Many Requests',
-                'req_1',
-                1,
-              );
-            }
-            return {
-              accessToken: newJwt,
-              refreshToken: 'new-rt',
-              user: mockUser,
-              impersonator: undefined,
-            };
-          },
-        },
-      };
+      const { client, getCallCount } = createRateLimitClient({
+        retryAfter: 1,
+        delayMs: 50,
+      });
       const testCore = new AuthKitCore(
         mockConfig as any,
         client as any,
@@ -722,7 +646,7 @@ describe('AuthKitCore', () => {
       await vi.advanceTimersByTimeAsync(1100);
       const results = await pending;
 
-      expect(callCount).toBe(2);
+      expect(getCallCount()).toBe(2);
       for (const r of results) {
         expect(r.accessToken).toBe(newJwt);
       }

--- a/src/core/AuthKitCore.spec.ts
+++ b/src/core/AuthKitCore.spec.ts
@@ -1,3 +1,4 @@
+import { RateLimitExceededException } from '@workos-inc/node';
 import { AuthKitCore } from './AuthKitCore.js';
 import { SessionEncryptionError, TokenRefreshError } from './errors.js';
 
@@ -402,6 +403,288 @@ describe('AuthKitCore', () => {
       await pending;
 
       expect(getCallCount()).toBe(2);
+      vi.useRealTimers();
+    });
+
+    it('retries once after a RateLimitExceededException', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', 2);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await pending;
+
+      expect(callCount).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('honors retryAfter from the exception', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', 5);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      // Advance less than the retryAfter — should not have retried yet
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(callCount).toBe(1);
+      // Advance past retryAfter
+      await vi.advanceTimersByTimeAsync(2000);
+      const result = await pending;
+
+      expect(callCount).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('defaults to 1s delay when retryAfter is null', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', null);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      await vi.advanceTimersByTimeAsync(1000);
+      const result = await pending;
+
+      expect(callCount).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('throws TokenRefreshError when retry also hits rate limit', async () => {
+      vi.useFakeTimers();
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1').catch(e => e);
+      await vi.advanceTimersByTimeAsync(1000);
+      const error = await pending;
+
+      expect(error).toBeInstanceOf(TokenRefreshError);
+      expect(error.message).toContain('after rate-limit retry');
+      vi.useRealTimers();
+    });
+
+    it('caps retryAfter at 10s', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', 300);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      // Should be capped at 10s, not 300s
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await pending;
+
+      expect(callCount).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('defaults to 1s for non-finite retryAfter values', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', Infinity as any);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1');
+      await vi.advanceTimersByTimeAsync(1000);
+      const result = await pending;
+
+      expect(callCount).toBe(2);
+      expect(result.accessToken).toBe(newJwt);
+      vi.useRealTimers();
+    });
+
+    it('wraps non-rate-limit retry errors correctly', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+            }
+            throw new Error('Network failure');
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = testCore.refreshTokens('rt-1').catch(e => e);
+      await vi.advanceTimersByTimeAsync(1000);
+      const error = await pending;
+
+      expect(callCount).toBe(2);
+      expect(error).toBeInstanceOf(TokenRefreshError);
+      expect(error.message).toContain('after rate-limit retry');
+      expect(error.cause).toBeInstanceOf(Error);
+      expect((error.cause as Error).message).toBe('Network failure');
+      vi.useRealTimers();
+    });
+
+    it('shares retry result with concurrent dedup waiters', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      const client = {
+        userManagement: {
+          getJwksUrl: () => 'https://api.workos.com/sso/jwks/test-client-id',
+          authenticateWithRefreshToken: async () => {
+            callCount++;
+            await new Promise(r => setTimeout(r, 50));
+            if (callCount === 1) {
+              throw new RateLimitExceededException('Too Many Requests', 'req_1', 1);
+            }
+            return {
+              accessToken: newJwt,
+              refreshToken: 'new-rt',
+              user: mockUser,
+              impersonator: undefined,
+            };
+          },
+        },
+      };
+      const testCore = new AuthKitCore(
+        mockConfig as any,
+        client as any,
+        mockEncryption as any,
+      );
+
+      const pending = Promise.all([
+        testCore.refreshTokens('rt-1'),
+        testCore.refreshTokens('rt-1'),
+        testCore.refreshTokens('rt-1'),
+      ]);
+
+      // First attempt (50ms) + retry delay (1000ms) + retry attempt (50ms)
+      await vi.advanceTimersByTimeAsync(1100);
+      const results = await pending;
+
+      expect(callCount).toBe(2);
+      for (const r of results) {
+        expect(r.accessToken).toBe(newJwt);
+      }
       vi.useRealTimers();
     });
   });

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -257,7 +257,7 @@ export class AuthKitCore {
             typeof raw === 'number' && Number.isFinite(raw) && raw > 0
               ? Math.min(raw, 10)
               : 1;
-          await new Promise((r) => setTimeout(r, delaySec * 1000));
+          await new Promise(r => setTimeout(r, delaySec * 1000));
           try {
             return await attempt();
           } catch (retryError) {

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -255,7 +255,7 @@ export class AuthKitCore {
           const raw = error.retryAfter;
           const delaySec =
             typeof raw === 'number' && Number.isFinite(raw) && raw > 0
-              ? Math.min(raw, 10)
+              ? Math.max(1, Math.min(raw, 10))
               : 1;
           await new Promise(r => setTimeout(r, delaySec * 1000));
           try {

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -261,6 +261,9 @@ export class AuthKitCore {
           try {
             return await attempt();
           } catch (retryError) {
+            if (retryError instanceof Error && !retryError.cause) {
+              retryError.cause = error;
+            }
             throw new TokenRefreshError(
               'Failed to refresh tokens after rate-limit retry',
               retryError,

--- a/src/core/AuthKitCore.ts
+++ b/src/core/AuthKitCore.ts
@@ -1,4 +1,9 @@
-import type { Impersonator, User, WorkOS } from '@workos-inc/node';
+import {
+  RateLimitExceededException,
+  type Impersonator,
+  type User,
+  type WorkOS,
+} from '@workos-inc/node';
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { constantTimeEqual, once } from '../utils.js';
 import type { AuthKitConfig } from './config/types.js';
@@ -228,21 +233,41 @@ export class AuthKitCore {
       this.inflightRefreshes.delete(key);
     };
     const promise = (async () => {
-      try {
+      const attempt = async () => {
         const result =
           await this.client.userManagement.authenticateWithRefreshToken({
             refreshToken,
             clientId: this.clientId,
             organizationId,
           });
-
         return {
           accessToken: result.accessToken,
           refreshToken: result.refreshToken,
           user: result.user,
           impersonator: result.impersonator,
         };
+      };
+
+      try {
+        return await attempt();
       } catch (error) {
+        if (error instanceof RateLimitExceededException) {
+          const raw = error.retryAfter;
+          const delaySec =
+            typeof raw === 'number' && Number.isFinite(raw) && raw > 0
+              ? Math.min(raw, 10)
+              : 1;
+          await new Promise((r) => setTimeout(r, delaySec * 1000));
+          try {
+            return await attempt();
+          } catch (retryError) {
+            throw new TokenRefreshError(
+              'Failed to refresh tokens after rate-limit retry',
+              retryError,
+              context,
+            );
+          }
+        }
         throw new TokenRefreshError('Failed to refresh tokens', error, context);
       }
     })();


### PR DESCRIPTION
## Summary

- Catches `RateLimitExceededException` in `refreshTokens()` and retries once after honoring the `Retry-After` delay
- Delay is clamped to 1–10s (defaults to 1s when `retryAfter` is null or non-finite)
- Retry lives inside the existing dedup promise, so all concurrent in-process waiters share the result
- Fixes cross-pod race condition where stateless multi-pod deployments (no LB session affinity) hit rate limits during concurrent token refresh

**Context:** Customer reported `RateLimitExceededException` during rolling deploys. Multiple pods read the same expired cookie and call `authenticateWithRefreshToken` simultaneously. The existing in-flight dedup (PR #33) handles within a single process, but cross-pod races still trigger rate limiting. WorkOS accepts reused refresh tokens within a ~10-30s grace window, so a single retry after the rate limit delay succeeds.

## Test plan

- [x] `pnpm build` passes
- [x] All 255 tests pass (8 new rate-limit retry tests)
- [x] Tests cover: basic retry, `retryAfter` honored, null fallback, double rate limit, 10s cap, non-finite values, non-rate-limit retry error, concurrent dedup sharing