### PR TITLE
fix: allow @workos-inc/node v10 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vitest": "^4.0.17"
   },
   "peerDependencies": {
-    "@workos-inc/node": "^8.0.0 || ^9.0.0"
+    "@workos-inc/node": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
- Widen the `@workos-inc/node` peer dependency range from `^8.0.0 || ^9.0.0` to also include `^10.0.0`.
- WorkOS published v10 of the Node SDK; this lets consumers on the new major install authkit-session without peer-dependency conflicts.
- Existing v8 and v9 users remain supported — the range is widened, not bumped.

c.f. https://github.com/workos/authkit-session/pull/32

## Test plan
- [ ] `npm install` against @workos-inc/node v10 resolves without peer-dependency warnings
- [ ] Existing test suite passes (`npm test`)
- [ ] No code changes required — packaging-only change