### PR TITLE
feat: bound pending PKCE verifier cookies with eviction

### DIFF
--- a/src/core/pkce/eviction.spec.ts
+++ b/src/core/pkce/eviction.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MAX_PENDING_PKCE_COOKIES,
+  isPKCEVerifierCookieName,
+  selectStalePKCEVerifierCookieNames,
+} from './eviction.js';
+import { PKCE_COOKIE_PREFIX, getPKCECookieNameForState } from './cookieName.js';
+
+const verifier = (state: string) => getPKCECookieNameForState(state);
+
+describe('isPKCEVerifierCookieName', () => {
+  it('matches the per-flow hashed name', () => {
+    expect(isPKCEVerifierCookieName(verifier('abc'))).toBe(true);
+  });
+
+  it('matches the legacy unsuffixed name', () => {
+    expect(isPKCEVerifierCookieName(PKCE_COOKIE_PREFIX)).toBe(true);
+  });
+
+  it('rejects unrelated cookies', () => {
+    expect(isPKCEVerifierCookieName('wos-session')).toBe(false);
+    expect(isPKCEVerifierCookieName('foo')).toBe(false);
+  });
+
+  it('rejects names that share the prefix without the hyphen boundary', () => {
+    // Guards against `wos-auth-verifierEVIL` being treated as a verifier.
+    expect(isPKCEVerifierCookieName(`${PKCE_COOKIE_PREFIX}EVIL`)).toBe(false);
+  });
+});
+
+describe('selectStalePKCEVerifierCookieNames', () => {
+  const keep = verifier('new-flow');
+
+  it('evicts nothing when the new cookie is the only verifier', () => {
+    expect(selectStalePKCEVerifierCookieNames([], { keep })).toEqual([]);
+  });
+
+  it('evicts nothing while total verifier count stays within the cap', () => {
+    // 4 existing + the new one = 5 = DEFAULT cap.
+    const existing = ['a', 'b', 'c', 'd'].map(verifier);
+    expect(selectStalePKCEVerifierCookieNames(existing, { keep })).toEqual([]);
+  });
+
+  it('evicts every other verifier once the new cookie tips it over the cap', () => {
+    // 5 existing + the new one = 6 > 5.
+    const existing = ['a', 'b', 'c', 'd', 'e'].map(verifier);
+    const stale = selectStalePKCEVerifierCookieNames(existing, { keep });
+    expect(new Set(stale)).toEqual(new Set(existing));
+    expect(stale).not.toContain(keep);
+  });
+
+  it('never evicts the cookie being kept, even if it is already on the request', () => {
+    const existing = ['a', 'b', 'c', 'd', keep];
+    // existing verifiers other than keep = 4; +1 new (keep, already counted) → within cap.
+    expect(selectStalePKCEVerifierCookieNames(existing, { keep })).toEqual([]);
+  });
+
+  it('ignores non-verifier cookies when counting', () => {
+    const existing = [
+      'wos-session',
+      'theme',
+      ...['a', 'b', 'c', 'd'].map(verifier),
+    ];
+    expect(selectStalePKCEVerifierCookieNames(existing, { keep })).toEqual([]);
+  });
+
+  it('honors a custom max', () => {
+    const existing = ['a', 'b'].map(verifier);
+    // 2 existing + 1 new = 3 > max:2 → evict both existing.
+    const stale = selectStalePKCEVerifierCookieNames(existing, {
+      keep,
+      max: 2,
+    });
+    expect(new Set(stale)).toEqual(new Set(existing));
+  });
+
+  it('exposes a sane default cap', () => {
+    expect(DEFAULT_MAX_PENDING_PKCE_COOKIES).toBe(5);
+  });
+});

--- a/src/core/pkce/eviction.spec.ts
+++ b/src/core/pkce/eviction.spec.ts
@@ -50,7 +50,7 @@ describe('selectStalePKCEVerifierCookieNames', () => {
   });
 
   it('never evicts the cookie being kept, even if it is already on the request', () => {
-    const existing = ['a', 'b', 'c', 'd', keep];
+    const existing = [...['a', 'b', 'c', 'd'].map(verifier), keep];
     // existing verifiers other than keep = 4; +1 new (keep, already counted) → within cap.
     expect(selectStalePKCEVerifierCookieNames(existing, { keep })).toEqual([]);
   });
@@ -72,6 +72,17 @@ describe('selectStalePKCEVerifierCookieNames', () => {
       max: 2,
     });
     expect(new Set(stale)).toEqual(new Set(existing));
+  });
+
+  it('evicts all others even when only slightly over the cap (partial over-cap)', () => {
+    // max=3, 3 existing + 1 new = 4 > 3 → evicts all 3 existing (not just the surplus).
+    const existing = ['a', 'b', 'c'].map(verifier);
+    const stale = selectStalePKCEVerifierCookieNames(existing, {
+      keep,
+      max: 3,
+    });
+    expect(new Set(stale)).toEqual(new Set(existing));
+    expect(stale).not.toContain(keep);
   });
 
   it('exposes a sane default cap', () => {

--- a/src/core/pkce/eviction.ts
+++ b/src/core/pkce/eviction.ts
@@ -1,0 +1,77 @@
+import { PKCE_COOKIE_PREFIX } from './cookieName.js';
+
+/**
+ * Default ceiling on simultaneous pending PKCE verifier cookies before
+ * eviction kicks in. Mirrors `authkit-nextjs`'s `MAX_PKCE_COOKIES`.
+ *
+ * A handful of concurrent flows is normal — e.g. several tabs each
+ * mid-sign-in, each holding its own verifier. Eviction only triggers
+ * once accumulation risks an oversized `Cookie` request header
+ * (HTTP 431), which happens when an integration generates authorization
+ * URLs it never navigates to (prefetching `getSignInUrl()` in a loader).
+ */
+export const DEFAULT_MAX_PENDING_PKCE_COOKIES = 5;
+
+/**
+ * True when `name` is a PKCE verifier cookie — either the per-flow hashed
+ * name (`wos-auth-verifier-<hash>`) or the legacy unsuffixed name.
+ *
+ * The hyphen boundary is required so a lookalike like
+ * `wos-auth-verifierXYZ` is NOT treated as a verifier.
+ */
+export function isPKCEVerifierCookieName(name: string): boolean {
+  return (
+    name === PKCE_COOKIE_PREFIX || name.startsWith(`${PKCE_COOKIE_PREFIX}-`)
+  );
+}
+
+/**
+ * Decide which stale PKCE verifier cookies to evict on the request that
+ * mints `keep`.
+ *
+ * The per-flow cookie naming (each `getSignInUrl()`/`getSignUpUrl()` call
+ * derives a unique name from its sealed state) means cookies never
+ * overwrite — they accumulate until their 10-minute TTL. Generating URLs
+ * without navigating to them (e.g. prefetching in a loader) can pile up
+ * enough verifier cookies to exceed the server's request-header limit and
+ * surface as HTTP 431.
+ *
+ * Policy (matches `authkit-nextjs`): tolerate up to `max` simultaneous
+ * verifier cookies. Once the cookie being created this request would push
+ * the total past `max`, evict *every* other verifier — keeping only the
+ * one just minted. Because cookie names are content hashes with no
+ * embedded ordering, "keep the newest N" is not expressible; all-but-newest
+ * is the only well-defined bounded policy, and it mirrors the browser's own
+ * drop-oldest behavior at the cookie-jar limit.
+ *
+ * Pure and I/O-free: callers supply the incoming cookie names and emit the
+ * delete `Set-Cookie` headers for the returned names themselves.
+ *
+ * @param cookieNames - Names of all cookies on the incoming request.
+ * @param keep - Name of the verifier cookie being written this request;
+ *   never included in the result.
+ * @param max - Maximum simultaneous verifier cookies tolerated before
+ *   eviction. Defaults to {@link DEFAULT_MAX_PENDING_PKCE_COOKIES}.
+ * @returns Verifier cookie names to delete. Empty when within budget.
+ */
+export function selectStalePKCEVerifierCookieNames(
+  cookieNames: Iterable<string>,
+  {
+    keep,
+    max = DEFAULT_MAX_PENDING_PKCE_COOKIES,
+  }: { keep: string; max?: number },
+): string[] {
+  const others = new Set<string>();
+  for (const name of cookieNames) {
+    if (name !== keep && isPKCEVerifierCookieName(name)) {
+      others.add(name);
+    }
+  }
+
+  // +1 accounts for `keep`, which may not be on the incoming request yet.
+  if (others.size + 1 <= max) {
+    return [];
+  }
+
+  return [...others];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,11 @@ export {
   PKCE_COOKIE_PREFIX,
   getPKCECookieNameForState,
 } from './core/pkce/cookieName.js';
+export {
+  DEFAULT_MAX_PENDING_PKCE_COOKIES,
+  isPKCEVerifierCookieName,
+  selectStalePKCEVerifierCookieNames,
+} from './core/pkce/eviction.js';
 
 // ============================================
 // Encryption Fallback

--- a/src/service/AuthService.spec.ts
+++ b/src/service/AuthService.spec.ts
@@ -426,6 +426,22 @@ describe('AuthService', () => {
       expect(result.headers?.['Set-Cookie']).toContain(`${staleName}=`);
     });
 
+    it('rejects non-PKCE cookie names', async () => {
+      const realStorage = makeStorage();
+      const realService = new AuthService(
+        mockConfig as any,
+        realStorage as any,
+        makeClient() as any,
+        sessionEncryption,
+      );
+
+      await expect(
+        realService.clearPendingVerifierByName(undefined, {
+          cookieName: 'wos-session',
+        }),
+      ).rejects.toThrow('Refusing to clear non-PKCE cookie "wos-session"');
+    });
+
     it('is what clearPendingVerifier delegates to (same options)', async () => {
       const realStorage = makeStorage();
       const realService = new AuthService(

--- a/src/service/AuthService.spec.ts
+++ b/src/service/AuthService.spec.ts
@@ -407,6 +407,48 @@ describe('AuthService', () => {
     });
   });
 
+  describe('clearPendingVerifierByName()', () => {
+    it('clears the named cookie without needing the sealed state', async () => {
+      const realStorage = makeStorage();
+      const realService = new AuthService(
+        mockConfig as any,
+        realStorage as any,
+        makeClient() as any,
+        sessionEncryption,
+      );
+
+      const staleName = 'wos-auth-verifier-deadbeef';
+      const result = await realService.clearPendingVerifierByName(undefined, {
+        cookieName: staleName,
+      });
+
+      expect(realStorage.lastClearOptions.get(staleName)?.path).toBe('/');
+      expect(result.headers?.['Set-Cookie']).toContain(`${staleName}=`);
+    });
+
+    it('is what clearPendingVerifier delegates to (same options)', async () => {
+      const realStorage = makeStorage();
+      const realService = new AuthService(
+        mockConfig as any,
+        realStorage as any,
+        makeClient() as any,
+        sessionEncryption,
+      );
+
+      const { cookieName } = await realService.createSignIn(undefined);
+      const sealedState = realStorage.cookies.get(cookieName)!;
+
+      const clearCookieSpy = vi.spyOn(realStorage, 'clearCookie');
+      await realService.clearPendingVerifier(undefined, { state: sealedState });
+
+      expect(clearCookieSpy).toHaveBeenCalledWith(
+        undefined,
+        cookieName,
+        expect.any(Object),
+      );
+    });
+  });
+
   describe('getWorkOS()', () => {
     it('returns WorkOS client', () => {
       const result = service.getWorkOS();

--- a/src/service/AuthService.spec.ts
+++ b/src/service/AuthService.spec.ts
@@ -408,15 +408,20 @@ describe('AuthService', () => {
   });
 
   describe('clearPendingVerifierByName()', () => {
-    it('clears the named cookie without needing the sealed state', async () => {
-      const realStorage = makeStorage();
-      const realService = new AuthService(
+    let realStorage: ReturnType<typeof makeStorage>;
+    let realService: InstanceType<typeof AuthService>;
+
+    beforeEach(() => {
+      realStorage = makeStorage();
+      realService = new AuthService(
         mockConfig as any,
         realStorage as any,
         makeClient() as any,
         sessionEncryption,
       );
+    });
 
+    it('clears the named cookie without needing the sealed state', async () => {
       const staleName = 'wos-auth-verifier-deadbeef';
       const result = await realService.clearPendingVerifierByName(undefined, {
         cookieName: staleName,
@@ -427,14 +432,6 @@ describe('AuthService', () => {
     });
 
     it('rejects non-PKCE cookie names', async () => {
-      const realStorage = makeStorage();
-      const realService = new AuthService(
-        mockConfig as any,
-        realStorage as any,
-        makeClient() as any,
-        sessionEncryption,
-      );
-
       await expect(
         realService.clearPendingVerifierByName(undefined, {
           cookieName: 'wos-session',
@@ -443,14 +440,6 @@ describe('AuthService', () => {
     });
 
     it('is what clearPendingVerifier delegates to (same options)', async () => {
-      const realStorage = makeStorage();
-      const realService = new AuthService(
-        mockConfig as any,
-        realStorage as any,
-        makeClient() as any,
-        sessionEncryption,
-      );
-
       const { cookieName } = await realService.createSignIn(undefined);
       const sealedState = realStorage.cookies.get(cookieName)!;
 

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -3,6 +3,7 @@ import { AuthKitCore } from '../core/AuthKitCore.js';
 import type { AuthKitConfig } from '../core/config/types.js';
 import { getPKCECookieNameForState } from '../core/pkce/cookieName.js';
 import { getPKCECookieOptions } from '../core/pkce/cookieOptions.js';
+import { isPKCEVerifierCookieName } from '../core/pkce/eviction.js';
 import { AuthOperations } from '../operations/AuthOperations.js';
 import type {
   AuthResult,
@@ -309,6 +310,11 @@ export class AuthService<TRequest, TResponse> {
     response: TResponse | undefined,
     options: { cookieName: string; redirectUri?: string },
   ): Promise<{ response?: TResponse; headers?: HeadersBag }> {
+    if (!isPKCEVerifierCookieName(options.cookieName)) {
+      throw new Error(
+        `Refusing to clear non-PKCE cookie "${options.cookieName}"`,
+      );
+    }
     return this.storage.clearCookie(
       response,
       options.cookieName,

--- a/src/service/AuthService.ts
+++ b/src/service/AuthService.ts
@@ -283,10 +283,35 @@ export class AuthService<TRequest, TResponse> {
     response: TResponse | undefined,
     options: { state: string; redirectUri?: string },
   ): Promise<{ response?: TResponse; headers?: HeadersBag }> {
-    const cookieName = getPKCECookieNameForState(options.state);
+    return this.clearPendingVerifierByName(response, {
+      cookieName: getPKCECookieNameForState(options.state),
+      redirectUri: options.redirectUri,
+    });
+  }
+
+  /**
+   * Emit a `Set-Cookie` header that clears a PKCE verifier cookie by its
+   * explicit name.
+   *
+   * Unlike {@link clearPendingVerifier}, this does not derive the name from
+   * a sealed `state` — it takes the cookie name directly. Use it to evict
+   * stale verifier cookies discovered by enumerating the request's cookies
+   * (e.g. via {@link selectStalePKCEVerifierCookieNames}), where the
+   * originating `state` is unknown and unrecoverable from the hashed name.
+   *
+   * The delete is computed with the same (name, path, domain) tuple the
+   * browser uses to match a cookie for replacement, so it clears the
+   * target regardless of the `redirectUri` the flow was created with. Pass
+   * `options.redirectUri` only when you need the `secure` attribute to match
+   * a per-request override.
+   */
+  async clearPendingVerifierByName(
+    response: TResponse | undefined,
+    options: { cookieName: string; redirectUri?: string },
+  ): Promise<{ response?: TResponse; headers?: HeadersBag }> {
     return this.storage.clearCookie(
       response,
-      cookieName,
+      options.cookieName,
       getPKCECookieOptions(this.config, options.redirectUri),
     );
   }


### PR DESCRIPTION
## Problem

Each authorization-URL call (`createSignIn` / `createSignUp` / `createAuthorization`) mints a uniquely-named `wos-auth-verifier-<hash>` cookie. The per-flow naming is deliberate — it lets concurrent sign-ins from multiple tabs coexist without clobbering each other (added in 0.5.x). The trade-off: because the name is derived from the sealed state (which embeds a fresh nonce + code verifier per call), **cookies never overwrite**. Generating URLs without navigating to them — e.g. prefetching `getSignInUrl()` in a route `loader` for display — leaves an orphan verifier cookie on every call. They accumulate until their 10-minute TTL, eventually bloating the `Cookie` request header into an **HTTP 431**.

This is the shared half of the fix for the consumer issue **workos/authkit-tanstack-start#76**.

## Approach

Mirror what `authkit-nextjs` already does (`src/pkce.ts`, `MAX_PKCE_COOKIES = 5`): tolerate a small number of concurrent verifier cookies, then bound the pile-up by evicting stale ones. Kept as a **pure, I/O-free primitive** so any adapter can reuse it — the framework owns reading the request and emitting `Set-Cookie`.

### New API

- **`selectStalePKCEVerifierCookieNames(cookieNames, { keep, max? })`** — given the request's cookie names and the verifier just minted (`keep`), returns the stale verifier names to delete once the total would exceed `max` (default `5`). Policy is *all-but-newest*: content-hashed names carry no ordering, so "keep the newest N" isn't expressible — this matches the browser's own drop-at-limit behavior.
- **`isPKCEVerifierCookieName(name)`** and **`DEFAULT_MAX_PENDING_PKCE_COOKIES`**.
- **`AuthService.clearPendingVerifierByName(response, { cookieName, redirectUri? })`** — clears a verifier by explicit name. `clearPendingVerifier` (which takes a sealed `state`) can't help here because the hashed name can't be reversed to a state; it now delegates to this method.

All three symbols are exported from the package index.

## Consumer wiring (for context, not in this PR)

The TanStack Start adapter calls these right after writing a new verifier: parse the incoming `Cookie` header, `selectStalePKCEVerifierCookieNames(names, { keep: result.cookieName })`, then `clearPendingVerifierByName` each stale name through its existing pending-`Set-Cookie` channel — best-effort, so a cleanup failure never breaks URL generation.

## Tests

- `src/core/pkce/eviction.spec.ts` — 11 cases (within-cap no-op, over-cap evict-all-others, never evicts `keep`, ignores non-verifier cookies, custom `max`, prefix-boundary guard).
- `src/service/AuthService.spec.ts` — `clearPendingVerifierByName` clears by name + `clearPendingVerifier` delegates with the same options.
- Full suite: **269 passing**. `format:check`, `lint`, `typecheck` clean.

## Note for reviewers

Typed as `feat:` because it adds public API surface (→ minor bump under release-please). If you'd rather this land as a patch so existing `^0.5.x` consumers pick it up on install without a manual dep bump, retitle to `fix:`. The eviction cap is currently the hardcoded `DEFAULT_MAX_PENDING_PKCE_COOKIES` (matching authkit-nextjs); happy to thread it through as an option if you want it configurable.