### PR TITLE
fix(factory): add clearPendingVerifierByName to createAuthService proxy

### DIFF
--- a/src/service/factory.spec.ts
+++ b/src/service/factory.spec.ts
@@ -44,6 +44,7 @@ describe('createAuthService', () => {
       expect(typeof service.createSignIn).toBe('function');
       expect(typeof service.createSignUp).toBe('function');
       expect(typeof service.clearPendingVerifier).toBe('function');
+      expect(typeof service.clearPendingVerifierByName).toBe('function');
       expect(typeof service.getWorkOS).toBe('function');
       expect(typeof service.handleCallback).toBe('function');
     });

--- a/src/service/factory.spec.ts
+++ b/src/service/factory.spec.ts
@@ -45,6 +45,8 @@ describe('createAuthService', () => {
       expect(typeof service.createSignUp).toBe('function');
       expect(typeof service.clearPendingVerifier).toBe('function');
       expect(typeof service.clearPendingVerifierByName).toBe('function');
+      expect(typeof service.switchOrganization).toBe('function');
+      expect(typeof service.refreshSession).toBe('function');
       expect(typeof service.getWorkOS).toBe('function');
       expect(typeof service.handleCallback).toBe('function');
     });

--- a/src/service/factory.ts
+++ b/src/service/factory.ts
@@ -78,6 +78,8 @@ export function createAuthService<TRequest, TResponse>(options: {
     createSignUp: (response, opts) => getService().createSignUp(response, opts),
     clearPendingVerifier: (response, opts) =>
       getService().clearPendingVerifier(response, opts),
+    clearPendingVerifierByName: (response, opts) =>
+      getService().clearPendingVerifierByName(response, opts),
     getWorkOS: () => getService().getWorkOS(),
     handleCallback: (request, response, opts) =>
       getService().handleCallback(request, response, opts),


### PR DESCRIPTION
## Summary

The proxy object returned by `createAuthService()` in `src/service/factory.ts` was missing the `clearPendingVerifierByName` delegation, causing the method to be `undefined` at runtime despite TypeScript's type assertion saying it exists. This adds the missing delegation entry so adapters can safely call `clearPendingVerifierByName()` as documented.

## What was tested

### Automated

- Full test suite: **271 tests passing**
- Typecheck: clean
- New assertion added in `factory.spec.ts` confirming `typeof service.clearPendingVerifierByName` is `'function'`

### Manual

- Scenario script reproducing the exact minimal check from issue #44:
  - `typeof service.clearPendingVerifierByName` → `'function'` (PASS with fix)
  - Reverted `factory.ts` to `main` → `typeof service.clearPendingVerifierByName` → `'undefined'` (FAIL confirms the bug)
- Verified all 14 proxy methods remain functions (no other methods inadvertently broken)

## Manual reproduction steps

1. On `main`, create a script that imports `createAuthService` and checks `typeof service.clearPendingVerifierByName`:

   ```ts
   import { createAuthService } from '@workos/authkit-session';

   const service = createAuthService({
     sessionStorageFactory: () => ({
       getCookie: async () => null,
       setCookie: async () => ({}),
       clearCookie: async () => ({}),
       getSession: async () => null,
       saveSession: async () => ({}),
       clearSession: async () => ({})
     })
   });

   console.log('typeof clearPendingVerifierByName:', typeof service.clearPendingVerifierByName);
   // On main: 'undefined' (BUG)
   // On this branch: 'function' (FIXED)
   ```

2. Run `pnpm build && node script.mjs` (or `tsx script.ts`)
3. **On `main`**: observe `undefined` — the method is missing from the proxy
4. **On `fix/issue-44`**: observe `'function'` — the delegation is present

## Verification

This is a library fix (no UI). Verification was performed via automated tests and a scenario script that reproduces the exact runtime check from issue #44. The revert test confirms the bug exists on `main` and is resolved on this branch.

## Issue

Closes #44

## Follow-ups

None — the fix is a minimal 3-line addition following the identical delegation pattern used by all other methods in the proxy.
