### PR TITLE
fix: include missing optionalKeys when building config from env

### DIFF
--- a/src/core/config/ConfigurationProvider.spec.ts
+++ b/src/core/config/ConfigurationProvider.spec.ts
@@ -91,6 +91,12 @@ describe('ConfigurationProvider', () => {
       expect(provider['getEnvironmentVariableName']('cookieMaxAge')).toBe(
         'WORKOS_COOKIE_MAX_AGE',
       );
+      expect(provider['getEnvironmentVariableName']('cookieDomain')).toBe(
+        'WORKOS_COOKIE_DOMAIN',
+      );
+      expect(provider['getEnvironmentVariableName']('cookieSameSite')).toBe(
+        'WORKOS_COOKIE_SAME_SITE',
+      );
     });
   });
 
@@ -117,6 +123,28 @@ describe('ConfigurationProvider', () => {
 
       const config = provider.getConfig();
       expect(config.cookieName).toBe('test-cookie');
+    });
+
+    it('reads optional env vars that have no defaults without configure()', () => {
+      const validPassword = 'a'.repeat(32);
+      const source = vi.fn((key: string) => {
+        if (key === 'WORKOS_CLIENT_ID') return 'env-client';
+        if (key === 'WORKOS_API_KEY') return 'env-api-key';
+        if (key === 'WORKOS_REDIRECT_URI')
+          return 'http://localhost:3000/callback';
+        if (key === 'WORKOS_COOKIE_PASSWORD') return validPassword;
+        if (key === 'WORKOS_COOKIE_DOMAIN') return '.example.com';
+        if (key === 'WORKOS_COOKIE_SAME_SITE') return 'strict';
+        if (key === 'WORKOS_API_PORT') return '8443';
+        return undefined;
+      });
+
+      provider.configure(source);
+
+      const config = provider.getConfig();
+      expect(config.cookieDomain).toBe('.example.com');
+      expect(config.cookieSameSite).toBe('strict');
+      expect(config.apiPort).toBe(8443);
     });
   });
 

--- a/src/core/config/ConfigurationProvider.ts
+++ b/src/core/config/ConfigurationProvider.ts
@@ -40,6 +40,12 @@ export class ConfigurationProvider {
     'cookiePassword',
   ];
 
+  private readonly optionalKeys: (keyof AuthKitConfig)[] = [
+    'apiPort',
+    'cookieSameSite',
+    'cookieDomain',
+  ];
+
   /**
    * Convert a camelCase string to an uppercase, underscore-separated environment variable name.
    * @param str The string to convert
@@ -184,6 +190,7 @@ export class ConfigurationProvider {
     const allKeys = new Set<keyof AuthKitConfig>([
       ...(Object.keys(this.config) as (keyof AuthKitConfig)[]),
       ...this.requiredKeys,
+      ...this.optionalKeys,
     ]);
 
     // Merge each key, with environment variables taking precedence

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -53,6 +53,7 @@ export interface AuthKitConfig {
 
   /**
    * The sameSite attribute for the session cookie
+   * Equivalent to the WORKOS_COOKIE_SAME_SITE environment variable
    */
   cookieSameSite?: 'strict' | 'lax' | 'none';
 
@@ -65,6 +66,7 @@ export interface AuthKitConfig {
 
   /**
    * The domain for the session cookie
+   * Equivalent to the WORKOS_COOKIE_DOMAIN environment variable
    */
   cookieDomain?: string;
 }


### PR DESCRIPTION
## Summary

Closes the config gap reported in https://github.com/workos/authkit-tanstack-start/issues/114. Setting `WORKOS_COOKIE_DOMAIN` (and the related optional env vars) had no effect unless callers also passed the value through `configure()`.

`getConfig()` built its key set from:

- keys already present on the default config object (`cookieName`, `apiHttps`, `cookieMaxAge`, `apiHostname`)
- `requiredKeys` (`clientId`, `apiKey`, `redirectUri`, `cookiePassword`)

Optional keys with **no defaults** — `cookieDomain`, `cookieSameSite`, `apiPort` — were never included, so their `WORKOS_*` env vars were never probed. Calling `configure({ cookieDomain })` hid the bug by putting the key on `this.config` via `updateConfig`.

This is why `@workos-inc/authkit-nextjs` was unaffected (it reads env vars through its own layer), while adapters that rely on `@workos/authkit-session` (TanStack Start and others) ignored `WORKOS_COOKIE_DOMAIN` and wrote session cookies without a `Domain` attribute.

## Changes

- Add `optionalKeys` (`apiPort`, `cookieSameSite`, `cookieDomain`) and include them in the `getConfig()` key set
- Document `WORKOS_COOKIE_DOMAIN` / `WORKOS_COOKIE_SAME_SITE` on the corresponding `AuthKitConfig` fields
- Add a regression test that sets those values **only** via the env value source (no `configure()` for those keys), so `updateConfig` cannot mask the failure

## Test plan

- [x] `pnpm test src/core/config/ConfigurationProvider.spec.ts` — optional env vars are read without `configure()`
- [x] Optional keys remain absent from `getConfig()` when unset
- [x] Existing required-key / default behavior unchanged
- [x] Manual: set `WORKOS_COOKIE_DOMAIN` in a TanStack Start app, sign in, confirm `Set-Cookie` includes `Domain=`